### PR TITLE
fix: iframe to use truncate when the content is long

### DIFF
--- a/apps/web/src/components/Shared/Oembed/Embed.tsx
+++ b/apps/web/src/components/Shared/Oembed/Embed.tsx
@@ -56,12 +56,12 @@ const Embed: FC<EmbedProps> = ({ og }) => {
             <div className="truncate p-5">
               <div className="space-y-1.5">
                 {og.title && (
-                  <div className="line-clamp-1 block text-ellipsis font-bold">
+                  <div className="line-clamp-1 truncate font-bold">
                     {og.title}
                   </div>
                 )}
                 {og.description && (
-                  <div className="lt-text-gray-500 line-clamp-2 block text-ellipsis">
+                  <div className="lt-text-gray-500 line-clamp-2 truncate">
                     {og.description}
                   </div>
                 )}


### PR DESCRIPTION
## What does this PR do?

Made the title and description in iframe to end with an ellipsis, in case it overflows

## Related issues

[Fixes # (issue)](https://github.com/lensterxyz/lenster/issues/1018)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Emoji

🚀 