### PR TITLE
fix: use ownedBy

### DIFF
--- a/apps/web/src/components/Home/HeyMembershipNft.tsx
+++ b/apps/web/src/components/Home/HeyMembershipNft.tsx
@@ -55,7 +55,7 @@ const HeyMembershipNft: FC = () => {
         axios.post(
           `${PREFERENCES_WORKER_URL}/updateHeyMemberNftStatus`,
           {
-            id: currentProfile?.id,
+            id: currentProfile?.ownedBy,
             dismissedOrMinted: true
           },
           {

--- a/apps/web/src/components/Home/HeyMembershipNft.tsx
+++ b/apps/web/src/components/Home/HeyMembershipNft.tsx
@@ -26,7 +26,7 @@ const HeyMembershipNft: FC = () => {
 
   const fetchPreferences = async (): Promise<MembershipNft> => {
     const response = await axios.get(
-      `${PREFERENCES_WORKER_URL}/getHeyMemberNftStatus/${currentProfile?.id}`
+      `${PREFERENCES_WORKER_URL}/getHeyMemberNftStatus/${currentProfile?.ownedBy}`
     );
     const { data } = response;
 

--- a/packages/data/errors.ts
+++ b/packages/data/errors.ts
@@ -7,6 +7,7 @@ export enum Errors {
   Limit500 = 'Limit must be less than 500!',
   InvalidAccesstoken = 'Invalid access token!',
   InvalidProfileId = 'Invalid profile id!',
+  InvalidAddress = 'Invalid address!',
   NotAdmin = 'You are not admin!',
   NoBody = 'No body provided!'
 }

--- a/packages/workers/preferences/src/handlers/updateHeyMemberNftStatus.ts
+++ b/packages/workers/preferences/src/handlers/updateHeyMemberNftStatus.ts
@@ -1,5 +1,4 @@
 import { Errors } from '@hey/data/errors';
-import hasOwnedLensProfiles from '@hey/lib/hasOwnedLensProfiles';
 import response from '@hey/lib/response';
 import validateLensAccount from '@hey/lib/validateLensAccount';
 import createSupabaseClient from '@hey/supabase/createSupabaseClient';
@@ -44,10 +43,9 @@ export default async (request: WorkerRequest) => {
     }
 
     const { payload } = jwt.decode(accessToken);
-    const hasOwned = await hasOwnedLensProfiles(payload.id, id, true);
-    if (!hasOwned) {
+    if (payload.id !== id) {
       return new Response(
-        JSON.stringify({ success: false, error: Errors.InvalidProfileId })
+        JSON.stringify({ success: false, error: Errors.InvalidAddress })
       );
     }
 


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at daef130</samp>

Fixed a bug in the web app and the preferences worker that prevented profiles with different addresses than their owners from accessing the membership NFT. Added a new `InvalidAddress` error type in the `data` package.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at daef130</samp>

*  Use `ownedBy` property instead of `id` property to check membership NFT eligibility in `HeyMembershipNft` component ([link](https://github.com/heyxyz/hey/pull/3849/files?diff=unified&w=0#diff-5388758711a26ddb26630c668d4791adc2ef36f1c29adfd0e066685a0ec1f860L29-R29), [link](https://github.com/heyxyz/hey/pull/3849/files?diff=unified&w=0#diff-5388758711a26ddb26630c668d4791adc2ef36f1c29adfd0e066685a0ec1f860L58-R58))
* Add `InvalidAddress` error to `Errors` enum in `data` package ([link](https://github.com/heyxyz/hey/pull/3849/files?diff=unified&w=0#diff-3566fa05f14a364ec7f5a7aa2cfd03e2ec00d1df45b6d9d7aa80baaab9a6ff0fR10))
* Remove `hasOwnedLensProfiles` function and use `InvalidAddress` error in `updateHeyMemberNftStatus` handler in `preferences` worker ([link](https://github.com/heyxyz/hey/pull/3849/files?diff=unified&w=0#diff-871c15233703c0ca7de2a979dd7af57cd88d1b6979acb01cfdb190c202fd033fL2), [link](https://github.com/heyxyz/hey/pull/3849/files?diff=unified&w=0#diff-871c15233703c0ca7de2a979dd7af57cd88d1b6979acb01cfdb190c202fd033fL47-R48))

## Emoji

<!--
copilot:emoji
-->

🚫🛠️🗑️

<!--
1.  🚫 for the `InvalidAddress` error, which indicates something is not allowed or blocked.
2.  🛠️ for the bug fix in the `HeyMembershipNft` component, which indicates something was repaired or improved.
3.  🗑️ for the removal of the `hasOwnedLensProfiles` function and the simplification of the code, which indicates something was deleted or cleaned up.
-->
