### PR TITLE
feat: add staff pick sidebar

### DIFF
--- a/apps/web/src/components/Home/StaffPicks/StaffPickedGroup.tsx
+++ b/apps/web/src/components/Home/StaffPicks/StaffPickedGroup.tsx
@@ -1,0 +1,37 @@
+import GroupProfile from '@components/Shared/GroupProfile';
+import GroupProfileShimmer from '@components/Shared/Shimmer/GroupProfileShimmer';
+import { CHANNELS_WORKER_URL } from '@hey/data/constants';
+import type { Channel } from '@hey/types/hey';
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
+import { type FC } from 'react';
+
+interface StaffPickedGroupProps {
+  id: string;
+}
+
+const StaffPickedGroup: FC<StaffPickedGroupProps> = ({ id }) => {
+  const fetchCommunity = async (): Promise<Channel> => {
+    const response: {
+      data: { result: Channel };
+    } = await axios.get(`${CHANNELS_WORKER_URL}/get/${id}`);
+
+    return response.data?.result;
+  };
+
+  const { data: channel, isLoading } = useQuery(['group', id], () =>
+    fetchCommunity().then((res) => res)
+  );
+
+  if (isLoading) {
+    return <GroupProfileShimmer />;
+  }
+
+  if (!channel) {
+    return null;
+  }
+
+  return <GroupProfile group={channel} />;
+};
+
+export default StaffPickedGroup;

--- a/apps/web/src/components/Home/StaffPicks/StaffPickedProfile.tsx
+++ b/apps/web/src/components/Home/StaffPicks/StaffPickedProfile.tsx
@@ -1,0 +1,28 @@
+import UserProfileShimmer from '@components/Shared/Shimmer/UserProfileShimmer';
+import UserProfile from '@components/Shared/UserProfile';
+import type { Profile } from '@hey/lens';
+import { useProfileQuery } from '@hey/lens';
+import { type FC } from 'react';
+
+interface StaffPickedProfileProps {
+  id: string;
+}
+
+const StaffPickedProfile: FC<StaffPickedProfileProps> = ({ id }) => {
+  const { data, loading } = useProfileQuery({
+    variables: { request: { profileId: id } },
+    skip: !Boolean(id)
+  });
+
+  if (loading) {
+    return <UserProfileShimmer />;
+  }
+
+  if (!data?.profile) {
+    return null;
+  }
+
+  return <UserProfile profile={data.profile as Profile} />;
+};
+
+export default StaffPickedProfile;

--- a/apps/web/src/components/Home/StaffPicks/index.tsx
+++ b/apps/web/src/components/Home/StaffPicks/index.tsx
@@ -1,0 +1,97 @@
+import GroupProfileShimmer from '@components/Shared/Shimmer/GroupProfileShimmer';
+import UserProfileShimmer from '@components/Shared/Shimmer/UserProfileShimmer';
+import { CursorArrowRippleIcon as CursorArrowRippleIconOutline } from '@heroicons/react/24/outline';
+import { CursorArrowRippleIcon as CursorArrowRippleIconSolid } from '@heroicons/react/24/solid';
+import { STAFF_PICKS_WORKER_URL } from '@hey/data/constants';
+import type { StaffPick } from '@hey/types/hey';
+import { Card, EmptyState, ErrorMessage } from '@hey/ui';
+import { t, Trans } from '@lingui/macro';
+import axios from 'axios';
+import { motion } from 'framer-motion';
+import type { FC } from 'react';
+import { useQuery } from 'wagmi';
+
+import StaffPickedGroup from './StaffPickedGroup';
+import StaffPickedProfile from './StaffPickedProfile';
+
+const Title = () => {
+  return (
+    <div className="mb-2 flex items-center gap-2 px-5 sm:px-0">
+      <CursorArrowRippleIconSolid className="text-brand h-4 w-4" />
+      <div>
+        <Trans>Staff Picks</Trans>
+      </div>
+    </div>
+  );
+};
+
+const StaffPicks: FC = () => {
+  const fetchStaffPicks = async (): Promise<StaffPick[]> => {
+    const response: {
+      data: { result: StaffPick[] };
+    } = await axios.get(`${STAFF_PICKS_WORKER_URL}/all`);
+
+    return response.data.result;
+  };
+
+  const {
+    data: picks,
+    isLoading,
+    error
+  } = useQuery(['fetchStaffPicks'], () => fetchStaffPicks().then((res) => res));
+
+  if (isLoading) {
+    return (
+      <>
+        <Title />
+        <Card className="mb-4 space-y-4 p-5">
+          <UserProfileShimmer />
+          <GroupProfileShimmer />
+          <UserProfileShimmer />
+          <GroupProfileShimmer />
+          <UserProfileShimmer />
+        </Card>
+      </>
+    );
+  }
+
+  if (picks?.length === 0) {
+    return (
+      <div className="mb-4">
+        <Title />
+        <EmptyState
+          message={t`No Staff picks!`}
+          icon={<CursorArrowRippleIconOutline className="text-brand h-8 w-8" />}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Title />
+      <Card as="aside" className="mb-4">
+        <div className="space-y-4 p-5">
+          <ErrorMessage
+            title={t`Failed to load recommendations`}
+            error={error as Error}
+          />
+          {picks?.map((pick) => (
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              key={pick.id}
+              className="flex items-center space-x-3 truncate"
+            >
+              {pick.type === 'PROFILE' && <StaffPickedProfile id={pick.id} />}
+              {pick.type === 'GROUP' && <StaffPickedGroup id={pick.id} />}
+            </motion.div>
+          ))}
+        </div>
+      </Card>
+    </>
+  );
+};
+
+export default StaffPicks;

--- a/apps/web/src/components/Home/index.tsx
+++ b/apps/web/src/components/Home/index.tsx
@@ -66,6 +66,7 @@ const Home: NextPage = () => {
         </GridItemEight>
         <GridItemFour>
           {/* <Gitcoin /> */}
+          {!currentProfile ? <Waitlist /> : null}
           <StaffPicks />
           {currentProfile ? (
             <>
@@ -76,9 +77,7 @@ const Home: NextPage = () => {
               <SetProfile />
               <RecommendedProfiles />
             </>
-          ) : (
-            <Waitlist />
-          )}
+          ) : null}
           <Footer />
         </GridItemFour>
       </GridLayout>

--- a/apps/web/src/components/Home/index.tsx
+++ b/apps/web/src/components/Home/index.tsx
@@ -23,6 +23,7 @@ import Highlights from './Highlights';
 import RecommendedProfiles from './RecommendedProfiles';
 import SetDefaultProfile from './SetDefaultProfile';
 import SetProfile from './SetProfile';
+import StaffPicks from './StaffPicks';
 import Timeline from './Timeline';
 import Waitlist from './Waitlist';
 
@@ -65,6 +66,7 @@ const Home: NextPage = () => {
         </GridItemEight>
         <GridItemFour>
           {/* <Gitcoin /> */}
+          <StaffPicks />
           {currentProfile ? (
             <>
               <HeyMembershipNft />

--- a/apps/web/src/components/Home/index.tsx
+++ b/apps/web/src/components/Home/index.tsx
@@ -37,6 +37,9 @@ const Home: NextPage = () => {
     Leafwatch.track(PAGEVIEW, { page: 'home' });
   });
 
+  const loggedIn = Boolean(currentProfile);
+  const loggedOut = !loggedIn;
+
   return (
     <>
       <MetaTags />
@@ -66,18 +69,18 @@ const Home: NextPage = () => {
         </GridItemEight>
         <GridItemFour>
           {/* <Gitcoin /> */}
-          {!currentProfile ? <Waitlist /> : null}
+          {loggedOut && <Waitlist />}
+          {loggedIn && <HeyMembershipNft />}
           <StaffPicks />
-          {currentProfile ? (
+          {loggedIn && (
             <>
-              <HeyMembershipNft />
               <EnableDispatcher />
               <EnableMessages />
               <SetDefaultProfile />
               <SetProfile />
               <RecommendedProfiles />
             </>
-          ) : null}
+          )}
           <Footer />
         </GridItemFour>
       </GridLayout>

--- a/apps/web/src/components/Shared/GroupProfile.tsx
+++ b/apps/web/src/components/Shared/GroupProfile.tsx
@@ -1,0 +1,68 @@
+import { FireIcon } from '@heroicons/react/24/solid';
+import getAvatar from '@hey/lib/getAvatar';
+import sanitizeDisplayName from '@hey/lib/sanitizeDisplayName';
+import type { Channel } from '@hey/types/hey';
+import { Image } from '@hey/ui';
+import Link from 'next/link';
+import type { FC } from 'react';
+import { memo } from 'react';
+
+import Slug from './Slug';
+
+interface GroupProfileProps {
+  group: Channel;
+  linkToProfile?: boolean;
+}
+
+const GroupProfile: FC<GroupProfileProps> = ({
+  group,
+  linkToProfile = true
+}) => {
+  const GroupAvatar = () => (
+    <Image
+      src={getAvatar(group)}
+      loading="lazy"
+      className="h-10 w-10 rounded-lg border bg-gray-200 dark:border-gray-700"
+      height={40}
+      width={40}
+      alt={group.slug}
+    />
+  );
+
+  const UserName = () => (
+    <>
+      <div className="flex max-w-sm items-center">
+        <div className="text-md grid">
+          <div className="truncate">{sanitizeDisplayName(group.name)}</div>
+        </div>
+        {group.featured ? (
+          <FireIcon className="ml-1 h-4 w-4 text-yellow-500" />
+        ) : null}
+      </div>
+      <div>
+        <Slug className="text-sm" slug={group.slug} prefix="g/" />
+      </div>
+    </>
+  );
+
+  const GroupInfo: FC = () => {
+    return (
+      <div className="mr-8 flex items-center space-x-3">
+        <GroupAvatar />
+        <div>
+          <UserName />
+        </div>
+      </div>
+    );
+  };
+
+  return linkToProfile ? (
+    <Link href={`/c/${group.slug}`}>
+      <GroupInfo />
+    </Link>
+  ) : (
+    <GroupInfo />
+  );
+};
+
+export default memo(GroupProfile);

--- a/apps/web/src/components/Shared/Shimmer/GroupProfileShimmer.tsx
+++ b/apps/web/src/components/Shared/Shimmer/GroupProfileShimmer.tsx
@@ -1,0 +1,17 @@
+import type { FC } from 'react';
+
+const GroupProfileShimmer: FC = () => {
+  return (
+    <div className="py-1">
+      <div className="flex items-center space-x-3">
+        <div className="shimmer h-10 w-10 rounded-lg" />
+        <div className="space-y-3">
+          <div className="shimmer h-3 w-28 rounded-lg" />
+          <div className="shimmer h-3 w-20 rounded-lg" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GroupProfileShimmer;

--- a/packages/data/constants.ts
+++ b/packages/data/constants.ts
@@ -110,6 +110,9 @@ export const CHANNELS_WORKER_URL = IS_PRODUCTION
 export const NFT_WORKER_URL = IS_PRODUCTION
   ? 'https://nft.hey.xyz'
   : 'http://localhost:8094';
+export const STAFF_PICKS_WORKER_URL = IS_PRODUCTION
+  ? 'https://staff-picks.hey.xyz'
+  : 'http://localhost:8095';
 
 // Tokens / Keys
 export const ALCHEMY_KEY = 'HHfOFn8jsYguteTVvL0cz4g9aydrbjTV';

--- a/packages/types/hey.d.ts
+++ b/packages/types/hey.d.ts
@@ -4,5 +4,7 @@ export type Channel = Database['public']['Tables']['channels']['Row'] & {
   members: number;
 };
 
+export type StaffPick = Database['public']['Tables']['staff-picks']['Row'];
+
 export type MembershipNft =
   Database['public']['Tables']['membership-nft']['Row'];

--- a/packages/workers/staff-picks/src/constants.ts
+++ b/packages/workers/staff-picks/src/constants.ts
@@ -1,0 +1,1 @@
+export const STAFFPICKS_KV_KEY = 'staff-picks-list';

--- a/packages/workers/staff-picks/src/handlers/getStaffPicks.ts
+++ b/packages/workers/staff-picks/src/handlers/getStaffPicks.ts
@@ -1,19 +1,26 @@
 import response from '@hey/lib/response';
 import createSupabaseClient from '@hey/supabase/createSupabaseClient';
 
+import { STAFFPICKS_KV_KEY } from '../constants';
 import type { WorkerRequest } from '../types';
 
 export default async (request: WorkerRequest) => {
   try {
-    const client = createSupabaseClient(request.env.SUPABASE_KEY);
+    const cache = await request.env.STAFFPICKS.get(STAFFPICKS_KV_KEY);
 
-    const { data } = await client
-      .from('staff-picks')
-      .select('*')
-      .order('score', { ascending: false })
-      .limit(10);
+    if (!cache) {
+      const client = createSupabaseClient(request.env.SUPABASE_KEY);
 
-    return response({ success: true, result: data });
+      const { data } = await client
+        .from('staff-picks')
+        .select('*')
+        .order('score', { ascending: false })
+        .limit(10);
+
+      return response({ success: true, result: data });
+    }
+
+    return response({ success: true, fromKV: true, result: JSON.parse(cache) });
   } catch (error) {
     throw error;
   }

--- a/packages/workers/staff-picks/src/types.ts
+++ b/packages/workers/staff-picks/src/types.ts
@@ -3,6 +3,7 @@ import type { IRequestStrict } from 'itty-router';
 export interface Env {
   RELEASE: string;
   SUPABASE_KEY: string;
+  STAFFPICKS: KVNamespace;
 }
 
 export type WorkerRequest = {

--- a/packages/workers/staff-picks/wrangler.toml
+++ b/packages/workers/staff-picks/wrangler.toml
@@ -8,6 +8,10 @@ routes = [
 	{ pattern = "staff-picks.hey.xyz", custom_domain = true }
 ]
 
+kv_namespaces = [
+  { binding = "STAFFPICKS", id = "589dbbe3a36d4f2c922c9c06393fc3d4", preview_id = "589dbbe3a36d4f2c922c9c06393fc3d4" }
+]
+
 [env.production.vars]
 RELEASE = ""
 SUPABASE_KEY = ""


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8cbe323</samp>

This pull request adds a new feature to the web app that displays a list of staff-picked items on the home page. It introduces several new components to render the staff picks, the group and user profiles, and the shimmer placeholders. It also adds a new constant for the staff picks worker URL.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8cbe323</samp>

*  Add a new feature to display staff picks on the home page ([link](https://github.com/heyxyz/hey/pull/3854/files?diff=unified&w=0#diff-1e0c36f1fd8d7a0211eeffd2774b6686081f15fe550031223f83adeb0b294405R26), [link](https://github.com/heyxyz/hey/pull/3854/files?diff=unified&w=0#diff-1e0c36f1fd8d7a0211eeffd2774b6686081f15fe550031223f83adeb0b294405R69), [link](https://github.com/heyxyz/hey/pull/3854/files?diff=unified&w=0#diff-47575b23700c7f6dbe41dac407a06d402a8746f883f7e0ea4ff32d0da451252fR1-R97))
*  Create a new component `StaffPicks` that queries and renders a list of staff picks from the `STAFF_PICKS_WORKER_URL` ([link](https://github.com/heyxyz/hey/pull/3854/files?diff=unified&w=0#diff-47575b23700c7f6dbe41dac407a06d402a8746f883f7e0ea4ff32d0da451252fR1-R97), [link](https://github.com/heyxyz/hey/pull/3854/files?diff=unified&w=0#diff-6ec8aa7fb4c2ed1478249a38aabfb5f5b619d73fbe771513d05679e976037348R113-R115))
*  Use wagmi, framer-motion and heroicons to handle data fetching, animation and icons in the `StaffPicks` component ([link](https://github.com/heyxyz/hey/pull/3854/files?diff=unified&w=0#diff-47575b23700c7f6dbe41dac407a06d402a8746f883f7e0ea4ff32d0da451252fR1-R97))
*  Create two new components `StaffPickedGroup` and `StaffPickedProfile` that render group and user profiles based on staff pick ids ([link](https://github.com/heyxyz/hey/pull/3854/files?diff=unified&w=0#diff-2b87c9074a52903e9c5c5e29590be9c98ef309897a432fc817be27770fb24607R1-R37), [link](https://github.com/heyxyz/hey/pull/3854/files?diff=unified&w=0#diff-0c8157d2fc614238b2873ff1a2824f9fdb43a3b4150790d8fe8ffce4de7b630cR1-R28))
*  Use react-query and `useProfileQuery` to fetch group and user data from the channels and lens workers respectively ([link](https://github.com/heyxyz/hey/pull/3854/files?diff=unified&w=0#diff-2b87c9074a52903e9c5c5e29590be9c98ef309897a432fc817be27770fb24607R1-R37), [link](https://github.com/heyxyz/hey/pull/3854/files?diff=unified&w=0#diff-0c8157d2fc614238b2873ff1a2824f9fdb43a3b4150790d8fe8ffce4de7b630cR1-R28))
*  Display shimmer placeholders while loading group and user data using `GroupProfileShimmer` and `ProfileShimmer` components ([link](https://github.com/heyxyz/hey/pull/3854/files?diff=unified&w=0#diff-2b87c9074a52903e9c5c5e29590be9c98ef309897a432fc817be27770fb24607R1-R37), [link](https://github.com/heyxyz/hey/pull/3854/files?diff=unified&w=0#diff-0c8157d2fc614238b2873ff1a2824f9fdb43a3b4150790d8fe8ffce4de7b630cR1-R28), [link](https://github.com/heyxyz/hey/pull/3854/files?diff=unified&w=0#diff-8167f20d96eddb148f1a3cd6897fb9dbe29ef1e46d4998bebd69f7848e0fceaeR1-R17))
*  Create a new component `GroupProfile` that renders a group avatar, name, slug and featured icon and optionally links to the group profile page ([link](https://github.com/heyxyz/hey/pull/3854/files?diff=unified&w=0#diff-f3822c01dd9f6092164dae544cc90fbc8454ef5c7216e03feb97172d8fd8ca66R1-R68))

## Emoji

<!--
copilot:emoji
-->

🌟🎨📦

<!--
1.  🌟 - This emoji represents the staff picks feature, which showcases the best and most interesting groups and profiles on the platform. It conveys a sense of quality, recognition and appreciation.
2.  🎨 - This emoji represents the design and animation aspects of the changes, which use framer-motion and heroicons to create a visually appealing and engaging UI. It conveys a sense of creativity, style and flair.
3.  📦 - This emoji represents the component-based approach of the changes, which use wagmi, react-query and lens to create reusable and modular components. It conveys a sense of structure, organization and efficiency.
-->
