### PR TITLE
feat: use urlcat for less mess

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -73,6 +73,7 @@
     "remark-linkify-regex": "^1.2.1",
     "shared-zustand": "^2.0.0",
     "strip-markdown": "^5.0.1",
+    "urlcat": "^3.1.0",
     "use-resize-observer": "^9.1.0",
     "usehooks-ts": "^2.9.1",
     "uuid": "^9.0.1",

--- a/apps/web/src/components/Channel/Details.tsx
+++ b/apps/web/src/components/Channel/Details.tsx
@@ -12,6 +12,7 @@ import Link from 'next/link';
 import { useTheme } from 'next-themes';
 import type { FC, ReactNode } from 'react';
 import { useState } from 'react';
+import urlcat from 'urlcat';
 import { create } from 'zustand';
 
 // Member count state
@@ -125,7 +126,9 @@ const Details: FC<DetailsProps> = ({ channel }) => {
               }
             >
               <Link
-                href={`https://x.com/${channel.x}`}
+                href={urlcat('https://x.com/:username', {
+                  username: channel.x
+                })}
                 target="_blank"
                 rel="noreferrer noopener"
               >
@@ -146,7 +149,9 @@ const Details: FC<DetailsProps> = ({ channel }) => {
               }
             >
               <Link
-                href={`https://instagram.com/${channel.instagram}`}
+                href={urlcat('https://instagram.com/:username', {
+                  username: channel.instagram
+                })}
                 target="_blank"
                 rel="noreferrer noopener"
               >

--- a/apps/web/src/components/Composer/NewPublication.tsx
+++ b/apps/web/src/components/Composer/NewPublication.tsx
@@ -89,6 +89,7 @@ import { useNonceStore } from 'src/store/nonce';
 import { usePublicationStore } from 'src/store/publication';
 import { useReferenceModuleStore } from 'src/store/reference-module';
 import { useTransactionPersistStore } from 'src/store/transaction';
+import urlcat from 'urlcat';
 import { useEffectOnce, useUpdateEffect } from 'usehooks-ts';
 import { v4 as uuid } from 'uuid';
 import { useContractWrite, usePublicClient, useSignTypedData } from 'wagmi';
@@ -748,7 +749,9 @@ const NewPublication: FC<NewPublicationProps> = ({ publication }) => {
         version: '2.0.0',
         metadata_id: uuid(),
         content: processedPublicationContent,
-        external_url: `https://hey.xyz/u/${currentProfile?.handle}`,
+        external_url: urlcat('https://hey.xyz/:handle', {
+          handle: currentProfile.handle
+        }),
         image:
           attachmentsInput.length > 0 ? getAttachmentImage() : textNftImageUrl,
         imageMimeType:

--- a/apps/web/src/components/Pages/Thanks.tsx
+++ b/apps/web/src/components/Pages/Thanks.tsx
@@ -8,6 +8,7 @@ import { t } from '@lingui/macro';
 import Link from 'next/link';
 import { useTheme } from 'next-themes';
 import type { FC, ReactNode } from 'react';
+import urlcat from 'urlcat';
 import { useEffectOnce } from 'usehooks-ts';
 
 interface BrandProps {
@@ -71,7 +72,10 @@ const Thanks: FC = () => {
               <Brand
                 name="Vercel"
                 logo="vercel"
-                url={`https://vercel.com/?utm_source=${APP_NAME}&utm_campaign=oss`}
+                url={urlcat('https://vercel.com', {
+                  utm_source: APP_NAME,
+                  utm_campaign: 'oss'
+                })}
                 size={40}
                 type="svg"
               >
@@ -82,7 +86,7 @@ const Thanks: FC = () => {
               <Brand
                 name="4EVERLAND"
                 logo="4everland"
-                url="https://4everland.org"
+                url={urlcat('https://4everland.org', { utm_source: APP_NAME })}
                 size={50}
                 type="png"
               >

--- a/apps/web/src/components/Profile/Details.tsx
+++ b/apps/web/src/components/Profile/Details.tsx
@@ -43,6 +43,7 @@ import { useMessageDb } from 'src/hooks/useMessageDb';
 import { useAppStore } from 'src/store/app';
 import { useMessageStore } from 'src/store/message';
 import { usePreferencesStore } from 'src/store/preferences';
+import urlcat from 'urlcat';
 
 import Badges from './Badges';
 import Followerings from './Followerings';
@@ -250,9 +251,10 @@ const Details: FC<DetailsProps> = ({ profile, following, setFollowing }) => {
           >
             <Tooltip content={`#${profile.id}`}>
               <Link
-                href={`${RARIBLE_URL}/token/polygon/${
-                  getEnvConfig().lensHubProxyAddress
-                }:${parseInt(profile.id)}`}
+                href={urlcat(RARIBLE_URL, '/token/polygon/:address::id', {
+                  address: getEnvConfig().lensHubProxyAddress,
+                  id: parseInt(profile.id)
+                })}
                 target="_blank"
                 rel="noreferrer"
               >
@@ -288,12 +290,11 @@ const Details: FC<DetailsProps> = ({ profile, following, setFollowing }) => {
             <MetaDetails
               icon={
                 <img
-                  src={`https://www.google.com/s2/favicons?domain=${getProfileAttribute(
-                    profile?.attributes,
-                    'website'
-                  )
-                    ?.replace('https://', '')
-                    .replace('http://', '')}`}
+                  src={urlcat('https://www.google.com/s2/favicons', {
+                    domain: getProfileAttribute(profile?.attributes, 'website')
+                      ?.replace('https://', '')
+                      .replace('http://', '')
+                  })}
                   className="h-4 w-4 rounded-full"
                   height={16}
                   width={16}
@@ -334,10 +335,12 @@ const Details: FC<DetailsProps> = ({ profile, following, setFollowing }) => {
               dataTestId="profile-meta-x"
             >
               <Link
-                href={`https://x.com/${getProfileAttribute(
-                  profile?.attributes,
-                  'x'
-                )?.replace('https://x.com/', '')}`}
+                href={urlcat('https://x.com/:username', {
+                  username: getProfileAttribute(
+                    profile?.attributes,
+                    'x'
+                  )?.replace('https://x.com/', '')
+                })}
                 target="_blank"
                 rel="noreferrer noopener"
               >

--- a/apps/web/src/components/Publication/Actions/Menu/Translate.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/Translate.tsx
@@ -8,6 +8,7 @@ import { Leafwatch } from '@lib/leafwatch';
 import { Trans } from '@lingui/macro';
 import Link from 'next/link';
 import type { FC } from 'react';
+import urlcat from 'urlcat';
 
 interface TranslateProps {
   publication: Publication;
@@ -16,7 +17,9 @@ interface TranslateProps {
 const Translate: FC<TranslateProps> = ({ publication }) => {
   const getGoogleTranslateUrl = (text: string): string => {
     return encodeURI(
-      `https://translate.google.com/#auto|en|${encodeURIComponent(text)}`
+      urlcat('https://translate.google.com/#auto|en|:text', {
+        text: encodeURIComponent(text)
+      })
     );
   };
 

--- a/apps/web/src/components/Publication/OnchainMeta.tsx
+++ b/apps/web/src/components/Publication/OnchainMeta.tsx
@@ -5,6 +5,7 @@ import { Card } from '@hey/ui';
 import { t } from '@lingui/macro';
 import Link from 'next/link';
 import type { FC } from 'react';
+import urlcat from 'urlcat';
 
 interface MetaProps {
   name: string;
@@ -55,16 +56,16 @@ const OnchainMeta: FC<OnchainMetaProps> = ({ publication }) => {
         {isArweaveHash ? (
           <Meta
             name={t`ARWEAVE TRANSACTION`}
-            uri={`https://arweave.app/tx/${hash}`}
+            uri={urlcat('https://arweave.net/tx/:hash', { hash })}
             hash={hash}
           />
         ) : null}
         {publication?.isDataAvailability ? (
           <Meta
             name={t`MOMOKA PROOF`}
-            uri={`https://momoka.lens.xyz/tx/${publication.dataAvailabilityProofs
-              ?.split('/')
-              .pop()}`}
+            uri={urlcat('https://momoka.lens.xyz/tx/:proof', {
+              proof: publication.dataAvailabilityProofs?.split('/').pop()
+            })}
             hash={
               publication.dataAvailabilityProofs?.split('/').pop() as string
             }

--- a/apps/web/src/components/Publication/OpenActions/Nft/BasePaintCanvas/index.tsx
+++ b/apps/web/src/components/Publication/OpenActions/Nft/BasePaintCanvas/index.tsx
@@ -11,6 +11,7 @@ import { t, Trans } from '@lingui/macro';
 import Link from 'next/link';
 import { type FC, useState } from 'react';
 import useBasePaintCanvas from 'src/hooks/basepaint/useBasePaintCanvas';
+import urlcat from 'urlcat';
 
 import Mint, { useBasePaintMintStore } from './Mint';
 import NftShimmer from './Shimmer';
@@ -113,7 +114,7 @@ const BasePaintCanvas: FC<BasePaintCanvasProps> = ({
           </>
         ) : canContribute ? (
           <Link
-            href={`https://basepaint.art/mint/${canvas.id}`}
+            href={urlcat('https://basepaint.art/mint/:id', { id: canvas.id })}
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -136,7 +137,10 @@ const BasePaintCanvas: FC<BasePaintCanvasProps> = ({
           </Link>
         ) : (
           <Link
-            href={`https://opensea.io/assets/base/${BASEPAINT_CONTRACT}/${canvas.id}`}
+            href={urlcat('https://opensea.io/assets/base/:contract/:token', {
+              contract: BASEPAINT_CONTRACT,
+              token: canvas.id
+            })}
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/apps/web/src/components/Publication/OpenActions/Nft/ZoraNft/index.tsx
+++ b/apps/web/src/components/Publication/OpenActions/Nft/ZoraNft/index.tsx
@@ -15,6 +15,7 @@ import { t, Trans } from '@lingui/macro';
 import Link from 'next/link';
 import { type FC, useState } from 'react';
 import useZoraNft from 'src/hooks/zora/useZoraNft';
+import urlcat from 'urlcat';
 
 import Mint, { useZoraMintStore } from './Mint';
 import NftShimmer from './Shimmer';
@@ -59,9 +60,11 @@ const ZoraNft: FC<ZoraNftProps> = ({ nftMetadata, publication }) => {
   ].includes(nft.contractType);
 
   const network = getZoraChainIsMainnet(chain) ? '' : 'testnet.';
-  const zoraLink = `https://${network}zora.co/collect/${chain}:${address}${
-    token ? `/${token}` : ''
-  }?referrer=${ADMIN_ADDRESS}`;
+  const zoraLink = urlcat(`https://${network}zora.co/collect/:chain::address`, {
+    chain,
+    address,
+    referrer: ADMIN_ADDRESS
+  });
 
   return (
     <Card
@@ -70,7 +73,11 @@ const ZoraNft: FC<ZoraNftProps> = ({ nftMetadata, publication }) => {
       onClick={(event) => stopEventPropagation(event)}
     >
       <img
-        src={`https://remote-image.decentralized-content.com/image?url=${nft.coverImageUrl}&w=1200&q=75`}
+        src={urlcat('https://remote-image.decentralized-content.com/image', {
+          url: nft.coverImageUrl,
+          w: 1200,
+          q: 75
+        })}
         className="h-[400px] max-h-[400px] w-full rounded-t-xl object-cover"
       />
       <div className="flex items-center justify-between border-t px-3 py-2 dark:border-gray-700">

--- a/apps/web/src/components/Publication/OpenActions/Snapshot/Header.tsx
+++ b/apps/web/src/components/Publication/OpenActions/Snapshot/Header.tsx
@@ -5,6 +5,7 @@ import { Image } from '@hey/ui';
 import cn from '@hey/ui/cn';
 import Link from 'next/link';
 import type { FC } from 'react';
+import urlcat from 'urlcat';
 
 interface HeaderProps {
   proposal: Proposal;
@@ -26,7 +27,9 @@ const Header: FC<HeaderProps> = ({ proposal }) => {
           {state}
         </div>
         <Image
-          src={`https://cdn.stamp.fyi/space/${space?.id}`}
+          src={urlcat('https://cdn.stamp.fyi/space/:address', {
+            address: space?.id
+          })}
           className="mr-1 h-5 w-5 rounded-full"
           alt={space?.id}
         />

--- a/apps/web/src/components/Settings/Profile/Profile.tsx
+++ b/apps/web/src/components/Settings/Profile/Profile.tsx
@@ -44,6 +44,7 @@ import { useState } from 'react';
 import toast from 'react-hot-toast';
 import useHandleWrongNetwork from 'src/hooks/useHandleWrongNetwork';
 import { useAppStore } from 'src/store/app';
+import urlcat from 'urlcat';
 import { v4 as uuid } from 'uuid';
 import { useContractWrite, useSignTypedData } from 'wagmi';
 import { object, string, union } from 'zod';
@@ -220,7 +221,7 @@ const ProfileSettingsForm: FC<ProfileSettingsFormProps> = ({ profile }) => {
 
       const request: CreatePublicSetProfileMetadataUriRequest = {
         profileId: currentProfile?.id,
-        metadata: `https://arweave.net/${id}`
+        metadata: urlcat('https://arweave.net/:id', { id })
       };
 
       if (canUseRelay && isSponsored) {

--- a/apps/web/src/components/Shared/Footer/index.tsx
+++ b/apps/web/src/components/Shared/Footer/index.tsx
@@ -5,6 +5,7 @@ import { Trans } from '@lingui/macro';
 import Link from 'next/link';
 import type { FC } from 'react';
 import { usePreferencesStore } from 'src/store/preferences';
+import urlcat from 'urlcat';
 
 import Locale from './Locale';
 
@@ -82,7 +83,10 @@ const Footer: FC = () => {
         <Locale />
         <Link
           className="hover:font-bold"
-          href={`https://vercel.com/?utm_source=${APP_NAME}&utm_campaign=oss`}
+          href={urlcat('https://vercel.com', {
+            utm_source: APP_NAME,
+            utm_campaign: 'oss'
+          })}
           target="_blank"
           rel="noreferrer noopener"
           onClick={() => Leafwatch.track(MISCELLANEOUS.FOOTER.OPEN_VERCEL)}

--- a/apps/web/src/components/Shared/Navbar/NavItems/AppVersion.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/AppVersion.tsx
@@ -1,6 +1,7 @@
 import { APP_VERSION } from '@hey/data/constants';
 import Link from 'next/link';
 import type { FC } from 'react';
+import urlcat from 'urlcat';
 
 interface AppVersionProps {
   onClick?: () => void;
@@ -10,7 +11,9 @@ const AppVersion: FC<AppVersionProps> = ({ onClick }) => {
   return (
     <div className="px-6 py-3 text-xs">
       <Link
-        href={`https://github.com/heyxyz/hey/releases/tag/v${APP_VERSION}`}
+        href={urlcat('https://github.com/heyxyz/hey/releases/tag/:version', {
+          version: `v${APP_VERSION}`
+        })}
         className="font-mono"
         target="_blank"
         rel="noreferrer noopener"

--- a/apps/web/src/components/Shared/Navbar/NavItems/ReportBug.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/ReportBug.tsx
@@ -6,6 +6,7 @@ import cn from '@hey/ui/cn';
 import { Trans } from '@lingui/macro';
 import Link from 'next/link';
 import type { FC } from 'react';
+import urlcat from 'urlcat';
 
 interface ReportBugProps {
   onClick?: () => void;
@@ -15,12 +16,16 @@ interface ReportBugProps {
 const ReportBug: FC<ReportBugProps> = ({ onClick, className = '' }) => {
   return (
     <Link
-      href="https://github.com/heyxyz/hey/issues/new?assignees=bigint&labels=needs+review&template=bug_report.yml"
-      target="_blank"
+      href={urlcat('https://github.com/heyxyz/hey/issues/new', {
+        assignees: 'bigint',
+        labels: 'needs review',
+        template: 'bug_report.yml'
+      })}
       className={cn(
         'flex w-full items-center justify-between px-2 py-1.5 text-sm text-gray-700 dark:text-gray-200',
         className
       )}
+      target="_blank"
       onClick={onClick}
     >
       <div className="flex items-center space-x-1.5">

--- a/apps/web/src/components/Shared/Navbar/StaffBar/index.tsx
+++ b/apps/web/src/components/Shared/Navbar/StaffBar/index.tsx
@@ -7,6 +7,7 @@ import { GIT_COMMIT_SHA, IS_MAINNET, IS_PRODUCTION } from '@hey/data/constants';
 import cn from '@hey/ui/cn';
 import Link from 'next/link';
 import type { FC, ReactNode } from 'react';
+import urlcat from 'urlcat';
 
 import Performance from './Performance';
 
@@ -41,7 +42,9 @@ const StaffBar: FC = () => {
         </div>
         {GIT_COMMIT_SHA ? (
           <Link
-            href={`https://github.com/heyxyz/hey/commit/${GIT_COMMIT_SHA}`}
+            href={urlcat('https://github.com/heyxyz/hey/commit/:sha', {
+              sha: GIT_COMMIT_SHA
+            })}
             className="flex items-center space-x-1"
             title="Git commit SHA"
             target="_blank"

--- a/apps/web/src/components/Shared/Oembed/index.tsx
+++ b/apps/web/src/components/Shared/Oembed/index.tsx
@@ -3,6 +3,7 @@ import type { OG } from '@hey/types/misc';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import type { FC } from 'react';
+import urlcat from 'urlcat';
 
 import Embed from './Embed';
 import Player from './Player';
@@ -34,7 +35,9 @@ const Oembed: FC<OembedProps> = ({ url, publicationId, onData }) => {
     title: data?.title,
     description: data?.description,
     site: data?.site,
-    favicon: `https://www.google.com/s2/favicons?domain=${data.url}`,
+    favicon: urlcat('https://www.google.com/s2/favicons', {
+      domain: data.url
+    }),
     image: data?.image,
     isLarge: data?.isLarge,
     html: data?.html

--- a/apps/web/src/components/StaffTools/Panels/Profile/Rank.tsx
+++ b/apps/web/src/components/StaffTools/Panels/Profile/Rank.tsx
@@ -12,6 +12,7 @@ import { t, Trans } from '@lingui/macro';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import type { FC } from 'react';
+import urlcat from 'urlcat';
 
 import MetaDetails from '../MetaDetails';
 
@@ -23,7 +24,10 @@ const Rank: FC<RankProps> = ({ profile }) => {
   const getRank = async (strategy: string) => {
     try {
       const response = await axios.get(
-        `https://lens-api.k3l.io/profile/rank?strategy=${strategy}&handle=${profile.handle}`
+        urlcat('https://lens-api.k3l.io/profile/rank', {
+          strategy,
+          handle: profile.handle
+        })
       );
 
       return response.data;
@@ -35,7 +39,10 @@ const Rank: FC<RankProps> = ({ profile }) => {
   const getGitcoinScore = async () => {
     try {
       const response = await axios.get(
-        `https://api.scorer.gitcoin.co/registry/score/335/${profile.ownedBy}`,
+        urlcat('https://api.scorer.gitcoin.co/registry/score/:id/:address', {
+          id: 335,
+          address: profile.ownedBy
+        }),
         {
           headers: { 'X-API-Key': 'xn9e7AFv.aEfS0ioNhaVtww1jdwnsWtxnrNHspVsS' }
         }

--- a/apps/web/src/hooks/opensea/useOpenseaCollection.ts
+++ b/apps/web/src/hooks/opensea/useOpenseaCollection.ts
@@ -2,6 +2,7 @@ import { OPENSEA_KEY } from '@hey/data/constants';
 import type { OpenSeaCollection } from '@hey/types/opensea-nft';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
+import urlcat from 'urlcat';
 
 interface UseOpenseaCollectionProps {
   slug: string;
@@ -18,7 +19,7 @@ const useOpenseaCollection = ({
 } => {
   const loadCollectionDetails = async () => {
     const response = await axios.get(
-      `https://api.opensea.io/api/v1/collection/${slug}`,
+      urlcat('https://api.opensea.io/api/v1/collection/:slug', { slug }),
       { headers: { 'X-API-KEY': OPENSEA_KEY } }
     );
 

--- a/apps/web/src/hooks/opensea/useOpenseaNft.ts
+++ b/apps/web/src/hooks/opensea/useOpenseaNft.ts
@@ -2,6 +2,7 @@ import { OPENSEA_KEY } from '@hey/data/constants';
 import type { OpenSeaNft } from '@hey/types/opensea-nft';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
+import urlcat from 'urlcat';
 
 interface UseOpenseaNftProps {
   chain: number;
@@ -37,7 +38,15 @@ const useOpenseaNft = ({
 
   const loadNftDetails = async () => {
     const response = await axios.get(
-      `https://api.opensea.io/v2/chain/${getOpenSeaChainName()}/contract/${address}/nfts/${token}`,
+      urlcat(
+        'https://api.opensea.io/v2/chains/:chain/contract/:address/nfts/:token',
+        {
+          chain: getOpenSeaChainName(),
+          address,
+          token,
+          format: 'json'
+        }
+      ),
       { headers: { 'X-API-KEY': OPENSEA_KEY } }
     );
 

--- a/packages/lib/getStampFyiURL.ts
+++ b/packages/lib/getStampFyiURL.ts
@@ -1,3 +1,5 @@
+import urlcat from 'urlcat';
+
 /**
  * Returns the cdn.stamp.fyi URL for the specified Ethereum address.
  *
@@ -6,7 +8,10 @@
  */
 const getStampFyiURL = (address: string): string => {
   const lowerCaseAddress = address.toLowerCase();
-  return `https://cdn.stamp.fyi/avatar/eth:${lowerCaseAddress}?s=300`;
+  return urlcat('https://cdn.stamp.fyi/avatar/eth::address', {
+    address: `eth:${lowerCaseAddress}`,
+    s: 300
+  });
 };
 
 export default getStampFyiURL;

--- a/packages/lib/getUniswapURL.ts
+++ b/packages/lib/getUniswapURL.ts
@@ -1,4 +1,5 @@
 import { IS_MAINNET } from '@hey/data/constants';
+import urlcat from 'urlcat';
 
 /**
  * Returns the Uniswap URL for the specified amount and output currency symbol.
@@ -8,8 +9,12 @@ import { IS_MAINNET } from '@hey/data/constants';
  * @returns The Uniswap URL.
  */
 const getUniswapURL = (amount: number, outputCurrency: string): string => {
-  const chain = IS_MAINNET ? 'polygon' : 'polygon_mumbai';
-  return `https://app.uniswap.org/#/swap?exactField=output&exactAmount=${amount}&outputCurrency=${outputCurrency}&chain=${chain}`;
+  return urlcat('https://app.uniswap.org/#/swap', {
+    exactField: 'output',
+    exactAmount: amount,
+    outputCurrency,
+    chain: IS_MAINNET ? 'polygon' : 'polygon_mumbai'
+  });
 };
 
 export default getUniswapURL;

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -16,6 +16,7 @@
     "@hey/lens": "workspace:*",
     "@hey/types": "workspace:*",
     "axios": "^1.5.1",
+    "urlcat": "^3.1.0",
     "viem": "^1.13.2"
   },
   "devDependencies": {

--- a/packages/workers/feeds/package.json
+++ b/packages/workers/feeds/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "@hey/data": "workspace:*",
     "@hey/lib": "workspace:*",
-    "itty-router": "^4.0.23"
+    "itty-router": "^4.0.23",
+    "urlcat": "^3.1.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230922.0",

--- a/packages/workers/feeds/src/providers/k3l/algorithms/k3lGlobalFeed.ts
+++ b/packages/workers/feeds/src/providers/k3l/algorithms/k3lGlobalFeed.ts
@@ -1,3 +1,5 @@
+import urlcat from 'urlcat';
+
 import randomizeIds from '../../../helpers/randomizeIds';
 
 const k3lGlobalFeed = async (
@@ -7,7 +9,11 @@ const k3lGlobalFeed = async (
 ) => {
   try {
     const response = await fetch(
-      `https://lens-api.k3l.io/feed/${strategy}?limit=${limit}&offset=${offset}`,
+      urlcat('https://lens-api.k3l.io/feed/:strategy', {
+        strategy,
+        limit,
+        offset
+      }),
       { headers: { 'User-Agent': 'Hey.xyz' } }
     );
     const json: {

--- a/packages/workers/feeds/src/providers/k3l/algorithms/k3lPersonalFeed.ts
+++ b/packages/workers/feeds/src/providers/k3l/algorithms/k3lPersonalFeed.ts
@@ -1,3 +1,5 @@
+import urlcat from 'urlcat';
+
 import randomizeIds from '../../../helpers/randomizeIds';
 
 const k3lPersonalFeed = async (
@@ -8,7 +10,12 @@ const k3lPersonalFeed = async (
 ) => {
   try {
     const response = await fetch(
-      `https://lens-api.k3l.io/feed/personal/${profile}/${strategy}?limit=${limit}&offset=${offset}`,
+      urlcat('https://lens-api.k3l.io/feed/personal/:profile/:strategy', {
+        profile,
+        strategy,
+        limit,
+        offset
+      }),
       { headers: { 'User-Agent': 'Hey.xyz' } }
     );
     const json: {

--- a/packages/workers/leafwatch/package.json
+++ b/packages/workers/leafwatch/package.json
@@ -17,6 +17,7 @@
     "@hey/lib": "workspace:*",
     "itty-router": "^4.0.23",
     "ua-parser-js": "^1.0.36",
+    "urlcat": "^3.1.0",
     "zod": "^3.22.2"
   },
   "devDependencies": {

--- a/packages/workers/leafwatch/src/handlers/ingest.ts
+++ b/packages/workers/leafwatch/src/handlers/ingest.ts
@@ -2,6 +2,7 @@ import { Errors } from '@hey/data/errors';
 import { ALL_EVENTS } from '@hey/data/tracking';
 import response from '@hey/lib/response';
 import UAParser from 'ua-parser-js';
+import urlcat from 'urlcat';
 import { any, object, string } from 'zod';
 
 import checkEventExistence from '../helpers/checkEventExistence';
@@ -60,7 +61,10 @@ export default async (request: WorkerRequest) => {
 
     try {
       const ipResponse = await fetch(
-        `https://pro.ip-api.com/json/${ip}?key=${request.env.IPAPI_KEY}`
+        urlcat('https://pro.ip-api.com/json/:ip', {
+          ip,
+          key: request.env.IPAPI_KEY
+        })
       );
       ipData = await ipResponse.json();
     } catch {}

--- a/packages/workers/nft/package.json
+++ b/packages/workers/nft/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "@hey/data": "workspace:*",
     "@hey/lib": "workspace:*",
-    "itty-router": "^4.0.23"
+    "itty-router": "^4.0.23",
+    "urlcat": "^3.1.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230922.0",

--- a/packages/workers/nft/src/handlers/getZoraNft.ts
+++ b/packages/workers/nft/src/handlers/getZoraNft.ts
@@ -1,5 +1,6 @@
 import getZoraChainIsMainnet from '@hey/lib/nft/getZoraChainIsMainnet';
 import response from '@hey/lib/response';
+import urlcat from 'urlcat';
 
 import type { WorkerRequest } from '../types';
 
@@ -16,14 +17,16 @@ export default async (request: WorkerRequest) => {
   try {
     const network = getZoraChainIsMainnet(chain as string) ? '' : 'testnet.';
     const zoraResponse = await fetch(
-      `https://${network}zora.co/api/personalize/collection/${chain}:${address}/${
-        token || ''
-      }`
+      urlcat(
+        `https://${network}zora.co/api/personalize/collection/:chain::address/:token`,
+        { chain, address, token: token || 0 }
+      )
     );
     const nft: { collection: any } = await zoraResponse.json();
 
     return response({ success: true, nft: nft.collection || null });
   } catch (error) {
+    console.error(error);
     throw error;
   }
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,9 @@ importers:
       strip-markdown:
         specifier: ^5.0.1
         version: 5.0.1
+      urlcat:
+        specifier: ^3.1.0
+        version: 3.1.0
       use-resize-observer:
         specifier: ^9.1.0
         version: 9.1.0(react-dom@18.2.0)(react@18.2.0)
@@ -14142,6 +14145,12 @@ packages:
 
   /url-polyfill@1.1.12:
     resolution: {integrity: sha512-mYFmBHCapZjtcNHW0MDq9967t+z4Dmg5CJ0KqysK3+ZbyoNOWQHksGCTWwDhxGXllkWlOc10Xfko6v4a3ucM6A==}
+    dev: false
+
+  /urlcat@3.1.0:
+    resolution: {integrity: sha512-qY6b94/aGMIHh70EEQ/4hfR2LUGZ+fPQNp64cf7yRX9kAp4XG2tx7LgYUU1Qkh17bFylME0u4n3lOezonougPw==}
+    dependencies:
+      qs: 6.11.2
     dev: false
 
   /urlpattern-polyfill@8.0.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -690,6 +690,9 @@ importers:
       itty-router:
         specifier: ^4.0.23
         version: 4.0.23
+      urlcat:
+        specifier: ^3.1.0
+        version: 3.1.0
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20230922.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -457,6 +457,9 @@ importers:
       axios:
         specifier: ^1.5.1
         version: 1.5.1
+      urlcat:
+        specifier: ^3.1.0
+        version: 3.1.0
       viem:
         specifier: ^1.13.2
         version: 1.14.0(typescript@5.2.2)(zod@3.22.2)
@@ -767,6 +770,9 @@ importers:
       ua-parser-js:
         specifier: ^1.0.36
         version: 1.0.36
+      urlcat:
+        specifier: ^3.1.0
+        version: 3.1.0
       zod:
         specifier: ^3.22.2
         version: 3.22.2
@@ -832,6 +838,9 @@ importers:
       itty-router:
         specifier: ^4.0.23
         version: 4.0.23
+      urlcat:
+        specifier: ^3.1.0
+        version: 3.1.0
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20230922.0


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cdb4d66</samp>

This pull request introduces the `urlcat` package as a dependency for the web app and refactors various components and hooks that use URLs to leverage the package's functionality. This improves the readability and maintainability of the code that constructs and parses URLs with query parameters. The pull request affects several files in the `apps/web/src/components` and `apps/web/src/hooks` directories, as well as the `apps/web/package.json` and `pnpm-lock.yaml` files.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cdb4d66</samp>

*  Add the urlcat package as a dependency to use a utility for building and parsing URLs ([link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8R76), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR240-R242), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR14150-R14155))
  - `Details` component for channel and profile information and links ([link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-543819ef93feccc82385ee6841a91bd658702e0f93e7f72a7867e19f6f9f8259R15), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-543819ef93feccc82385ee6841a91bd658702e0f93e7f72a7867e19f6f9f8259L128-R131), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-543819ef93feccc82385ee6841a91bd658702e0f93e7f72a7867e19f6f9f8259L149-R154), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-051c5aa8ed716f2a43344cf26ef7f981c4ad1884f3cf442ae394da8e5527aa04R46), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-051c5aa8ed716f2a43344cf26ef7f981c4ad1884f3cf442ae394da8e5527aa04L253-R257), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-051c5aa8ed716f2a43344cf26ef7f981c4ad1884f3cf442ae394da8e5527aa04L291-R297), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-051c5aa8ed716f2a43344cf26ef7f981c4ad1884f3cf442ae394da8e5527aa04L337-R343))
  - `NewPublication` component for publication metadata fields ([link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-175403612af948ab5a9aed1b111d24448b156cc856927d47f556e01221a56517R92), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-175403612af948ab5a9aed1b111d24448b156cc856927d47f556e01221a56517L751-R754))
  - `Thanks` and `Footer` components for sponsor links ([link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-accbf55ac70b84c8e468a84b29f2b04d5480687988cf5a4018ef592bf40434dbR11), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-accbf55ac70b84c8e468a84b29f2b04d5480687988cf5a4018ef592bf40434dbL74-R78), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-accbf55ac70b84c8e468a84b29f2b04d5480687988cf5a4018ef592bf40434dbL85-R89), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-df48af4cfbfbbebd7f281357b2470d7ec91d650c4fbe302af79f79f9e733c541R8), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-df48af4cfbfbbebd7f281357b2470d7ec91d650c4fbe302af79f79f9e733c541L85-R89))
  - `OnchainMeta` component for on-chain metadata sources ([link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-0e0b11ed8e8f757115c7cba9baab8d7b185c0f178ce22cde62478e3e42494086R8), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-0e0b11ed8e8f757115c7cba9baab8d7b185c0f178ce22cde62478e3e42494086L58-R59), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-0e0b11ed8e8f757115c7cba9baab8d7b185c0f178ce22cde62478e3e42494086L65-R68))
  - `BasePaintCanvas` and `ZoraNft` components for NFT platforms ([link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-796f6cff651d4f0b8bb1489cdb606c406d36101b3225de27c27604dbda6d9ceeR14), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-796f6cff651d4f0b8bb1489cdb606c406d36101b3225de27c27604dbda6d9ceeL116-R117), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-796f6cff651d4f0b8bb1489cdb606c406d36101b3225de27c27604dbda6d9ceeL139-R143), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-e001c9aeec96f89b82593a03374c362ef6fb50abd10b0bf7f212320f1f1d9dc1R18), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-e001c9aeec96f89b82593a03374c362ef6fb50abd10b0bf7f212320f1f1d9dc1L62-R67), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-e001c9aeec96f89b82593a03374c362ef6fb50abd10b0bf7f212320f1f1d9dc1L73-R80))
  - `Translate` component for Google Translate URL ([link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-416530b39f8648e77fa13599dc1e1c30ee67574919212a864620f0e51aebb39eR11), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-416530b39f8648e77fa13599dc1e1c30ee67574919212a864620f0e51aebb39eL19-R22))
  - `Header` component for Snapshot space logo ([link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-b5ffd9d9b3c89663766320b804e4bd07b7c0c13a13816ab9ed8f43d759bccb34R8), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-b5ffd9d9b3c89663766320b804e4bd07b7c0c13a13816ab9ed8f43d759bccb34L29-R32))
  - `Profile` component for profile metadata field ([link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-cc605dc6510d575486ca4cc4d51a003ca10dfeb338fced8f413d3c60d1543c90R47), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-cc605dc6510d575486ca4cc4d51a003ca10dfeb338fced8f413d3c60d1543c90L223-R224))
  - `AppVersion` component for GitHub release link ([link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-7fee9c40b14f5f2e6e1d4047f190e290d1d1e8fc03c0ec5a8d037956f2a346efR4), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-7fee9c40b14f5f2e6e1d4047f190e290d1d1e8fc03c0ec5a8d037956f2a346efL13-R16))
  - `ReportBug` component for GitHub issue template link ([link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-4afd3014c22414d4989ec9310dc702e6baad332acd2a51c25e0ce1bc993d41ecR9), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-4afd3014c22414d4989ec9310dc702e6baad332acd2a51c25e0ce1bc993d41ecL18-R28))
  - `StaffBar` component for GitHub commit link ([link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-2f55bc47eb883b66969367f474443d9d1783bcbfa84f96934292a9960c95595eR10), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-2f55bc47eb883b66969367f474443d9d1783bcbfa84f96934292a9960c95595eL44-R47))
  - `Oembed` component for favicon attribute ([link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-f0d9a6717e6f27cd1933024af5037010bd1b2d5dd083e41605ae1c9c5cee84faR6), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-f0d9a6717e6f27cd1933024af5037010bd1b2d5dd083e41605ae1c9c5cee84faL37-R40))
  - `Rank` component for rank data API requests ([link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-bba52cf6056a25cc0167219a84c76cf99576af1e28c216b6f124958a11bb94a1R15), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-bba52cf6056a25cc0167219a84c76cf99576af1e28c216b6f124958a11bb94a1L26-R30), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-bba52cf6056a25cc0167219a84c76cf99576af1e28c216b6f124958a11bb94a1L38-R45))
  - `useOpenseaCollection` and `useOpenseaNft` hooks for OpenSea API requests ([link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-5c632b26554b013ca36630f1ccd2e503582d3c86807e0eabf84b2836a7d0fd2aR5), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-5c632b26554b013ca36630f1ccd2e503582d3c86807e0eabf84b2836a7d0fd2aL21-R22), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-a7e123db43f335f06542d723263dbb86bce32dbf95b128fd095c5ab7f5142c28R5), [link](https://github.com/heyxyz/hey/pull/3856/files?diff=unified&w=0#diff-a7e123db43f335f06542d723263dbb86bce32dbf95b128fd095c5ab7f5142c28L40-R49))

## Emoji

<!--
copilot:emoji
-->

🌐🛠️🖼️

<!--
1.  🌐 - This emoji represents the web app and the URL-related changes.
2.  🛠️ - This emoji represents the dependency addition and the code improvement.
3.  🖼️ - This emoji represents the NFT and OpenSea features.
-->
