### PR TITLE
feat: disable delete option if profile guardian is enabled

### DIFF
--- a/apps/web/src/components/Settings/Danger/Delete.tsx
+++ b/apps/web/src/components/Settings/Danger/Delete.tsx
@@ -21,6 +21,7 @@ import useHandleWrongNetwork from 'src/hooks/useHandleWrongNetwork';
 import { useDisconnectXmtp } from 'src/hooks/useXmtpClient';
 import { useAppPersistStore, useAppStore } from 'src/store/app';
 import { useNonceStore } from 'src/store/nonce';
+import { useProfileGuardianInformationStore } from 'src/store/profile-guardian-information';
 import { useContractWrite, useDisconnect } from 'wagmi';
 
 const DeleteSettings: FC = () => {
@@ -34,6 +35,9 @@ const DeleteSettings: FC = () => {
   const disconnectXmtp = useDisconnectXmtp();
   const { disconnect } = useDisconnect();
   const handleWrongNetwork = useHandleWrongNetwork();
+  const profileGuardianInformation = useProfileGuardianInformationStore(
+    (state) => state.profileGuardianInformation
+  );
 
   const onCompleted = () => {
     Leafwatch.track(SETTINGS.DANGER.DELETE_PROFILE);
@@ -95,11 +99,34 @@ const DeleteSettings: FC = () => {
     }
   };
 
+  const cooldownEnded = () => {
+    const cooldownDate =
+      profileGuardianInformation.disablingProtectionTimestamp as any;
+    return new Date(cooldownDate).getTime() < Date.now();
+  };
+
+  const canDelete = !profileGuardianInformation.isProtected && cooldownEnded();
+
+  if (!canDelete) {
+    return (
+      <Card className="space-y-5 p-5">
+        <div className="text-lg font-bold text-red-500">
+          <Trans>Delete Lens profile</Trans>
+        </div>
+        <p>
+          <Trans>
+            Your profile cannot be deleted while profile guardian is enabled.
+          </Trans>
+        </p>
+      </Card>
+    );
+  }
+
   return (
     <Card className="space-y-5 p-5">
       <UserProfile profile={currentProfile as Profile} />
       <div className="text-lg font-bold text-red-500">
-        <Trans>This will delete your Lens profile</Trans>
+        <Trans>Delete Lens profile</Trans>
       </div>
       <p>
         <Trans>


### PR DESCRIPTION
## What does this PR do?

Fixes #3729

**guardian enabled:**
![Screenshot_2023-10-02_08-53-25 (copy 1)](https://github.com/heyxyz/hey/assets/667227/c890a1f4-5b80-4234-96cc-4cce58cd8c36)


**guardian disabled, cooldown:**
![Screenshot_2023-10-02_08-52-47 (copy 1)](https://github.com/heyxyz/hey/assets/667227/78a3ec0f-25bd-418b-8e57-f33f3a233d35)



**guardian disabled:**
![Screenshot_2023-10-02_09-00-24](https://github.com/heyxyz/hey/assets/667227/1beaa6a1-55cc-4394-a89b-83ea8390a560)




<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b8b4bf9</samp>

Add profile guardian protection to profile deletion settings. This prevents users from accidentally or maliciously deleting their profiles if they have a trusted contact who can restore them. The change affects the `DeleteSettings` component and the `useProfileGuardianInformationStore` hook.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b8b4bf9</samp>

*  Implement profile guardian feature to prevent profile deletion in case of account compromise or coercion ([link](https://github.com/heyxyz/hey/pull/3857/files?diff=unified&w=0#diff-aae51350297a3caa87f5b2cfa0307b6b207a4891cfb3be7074a340b9eb9b6df6R24), [link](https://github.com/heyxyz/hey/pull/3857/files?diff=unified&w=0#diff-aae51350297a3caa87f5b2cfa0307b6b207a4891cfb3be7074a340b9eb9b6df6R38-R40), [link](https://github.com/heyxyz/hey/pull/3857/files?diff=unified&w=0#diff-aae51350297a3caa87f5b2cfa0307b6b207a4891cfb3be7074a340b9eb9b6df6L98-R129))

## Emoji

<!--
copilot:emoji
-->

🔒🗑️🚫

<!--
1.  🔒 - This emoji represents the profile guardian protection feature, which locks the profile from being deleted by unauthorized users.
2.  🗑️ - This emoji represents the deletion action, which removes the profile and all its associated data from the platform.
3.  🚫 - This emoji represents the deletion ineligibility, which prevents the user from deleting their profile if they have enabled profile guardian protection and have not entered the correct guardian code.
-->
