### PR TITLE
feat: prevent blankline commits

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -18,13 +18,9 @@ jobs:
         with:
           upload_translations: false
           download_translations: true
-          create_pull_request: true
+          create_pull_request: false
           project_id: ${{ secrets.CROWDIN_PROJECT_ID }}
           token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
-          pull_request_title: 'chore(i18n): synchronize translations from crowdin'
-          pull_request_body: 'New Crowdin pull request with translations'
-          pull_request_assignees: 'crowdin-bot'
-          pull_request_reviewers: 'bigint'
           source: '/**/locales/en/*.po'
           translation: '/**/locales/%two_letters_code%/%original_file_name%'
         env:
@@ -33,3 +29,13 @@ jobs:
       - name: Remove last empty lines from translations
         run: |
           find '/**/locales/' -type f -name '*.po' -exec sed -i -e '${/^$/d;}' {} \;
+      
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          title: 'chore(i18n): synchronize translations from crowdin'
+          body: 'New Crowdin pull request with translations'
+          assignees: 'crowdin-bot'
+          reviewers: 'bigint'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -29,3 +29,7 @@ jobs:
           translation: '/**/locales/%two_letters_code%/%original_file_name%'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Remove last empty lines from translations
+        run: |
+          find '/**/locales/' -type f -name '*.po' -exec sed -i -e '${/^$/d;}' {} \;

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,12 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+if [ -z "$(git diff --cached --ignore-blank-lines --unified=0 | grep -E '^[+-]\s' | grep -vE '^[+-]\s*$')" ]; then
+  echo "Error: commit must contain new content."
+  exit 1
+else
+  exit 0
+fi
+
 pnpm lint:affected
 pnpm typecheck:affected

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,12 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-if [ -z "$(git diff --cached --ignore-blank-lines --unified=0 | grep -E '^[+-]\s' | grep -vE '^[+-]\s*$')" ]; then
-  echo "Error: commit must contain new content."
-  exit 1
-else
-  exit 0
-fi
 
 pnpm lint:affected
 pnpm typecheck:affected


### PR DESCRIPTION
## What does this PR do?

It prevents commits that contain only blank lines.

## Related issues

Fixes # 3807

/claim #3807

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

- changed the pre-commit hook that checks if the staged changes only contain blank lines before committing the changes.

## Emoji

✅ ✅ ✅ 

