### PR TITLE
Added hey PWA support

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,1 +1,8 @@
 src/locales/**/*.js
+
+public/sw.js
+public/workbox-*.js
+public/worker-*.js
+public/sw.js.map
+public/workbox-*.js.map
+public/worker-*.js.map

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,9 +1,16 @@
 const linguiConfig = require('./lingui.config');
+const withPWA = require('next-pwa')({
+  dest: '/public',
+  register: true,
+  skipWaiting: true,
+  // disableDevLogs: true,
+  // disable: process.env.NODE_ENV === 'development'
+});
 
 const headers = [{ key: 'Cache-Control', value: 'public, max-age=3600' }];
 
 /** @type {import('next').NextConfig} */
-const nextConfig = {
+const nextConfig = withPWA({
   productionBrowserSourceMaps: true,
   transpilePackages: ['data'],
   reactStrictMode: false,
@@ -72,6 +79,6 @@ const nextConfig = {
       { source: '/thanks', headers }
     ];
   }
-};
+});
 
 module.exports = nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -58,6 +58,7 @@
     "idb-keyval": "^6.2.1",
     "lexical": "^0.12.2",
     "next": "^13.5.4",
+    "next-pwa": "^5.6.0",
     "next-themes": "^0.2.1",
     "plyr-react": "^5.3.0",
     "rc-slider": "^10.3.0",

--- a/apps/web/public/manifest.json
+++ b/apps/web/public/manifest.json
@@ -11,7 +11,8 @@
     {
       "src": "/icon-128x128.png",
       "sizes": "128x128",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any maskable"
     },
     {
       "src": "/icon-512x512.png",


### PR DESCRIPTION
## What does this PR do?
Adds fully native PWA Service Worker support, and updates an icon object to be a maskable icon in `manifest.json` for better PWA support.

## Related issues

Fixes #3865 
/claim #3865 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes
- Added full PWA support with a service worker.
- Changes to the `manifest.json` includes adding a `"purpose": "any maskable"` to a icon object, to have better PWA support.
- Added couple of files to the `.gitignore` in `apps/web`, those files being auto generated service worker related files.
- Updated `next.config.js` for PWA support.

![image](https://github.com/heyxyz/hey/assets/101876769/9ca2053d-4c09-42e0-b9c4-7afd7980a159)


## Emoji

<!--
copilot:emoji
-->

🚫📦🚀

<!--
1.  🚫 for adding files to the .gitignore file, as it means to ignore or exclude something.
2.  📦 for adding a new dependency to the package.json file, as it means to package or bundle something.
3.  🚀 for adding progressive web app support and improving the icon, as it means to launch or deploy something.
-->
