### PR TITLE
fix: cooldown message

### DIFF
--- a/apps/web/src/components/Settings/Danger/Guardian.tsx
+++ b/apps/web/src/components/Settings/Danger/Guardian.tsx
@@ -81,8 +81,8 @@ const GuardianSettings: FC = () => {
       <div className="lt-text-gray-500 divide-y text-sm dark:divide-gray-700">
         <p className="pb-3">
           <Trans>
-            A 5-minute Security Cooldown Period need to be elapsed for the
-            Profile Guardian to become effectively disabled.
+            A 7-day Security Cooldown Period need to be elapsed for the Profile
+            Guardian to become effectively disabled.
           </Trans>
         </p>
         <p className="py-3">

--- a/apps/web/src/components/Settings/Danger/Guardian.tsx
+++ b/apps/web/src/components/Settings/Danger/Guardian.tsx
@@ -81,8 +81,8 @@ const GuardianSettings: FC = () => {
       <div className="lt-text-gray-500 divide-y text-sm dark:divide-gray-700">
         <p className="pb-3">
           <Trans>
-            A 7-day Security Cooldown Period need to be elapsed for the Profile
-            Guardian to become effectively disabled.
+            A 5-minute Security Cooldown Period need to be elapsed for the
+            Profile Guardian to become effectively disabled.
           </Trans>
         </p>
         <p className="py-3">

--- a/apps/web/src/components/Shared/CountdownTimer.tsx
+++ b/apps/web/src/components/Shared/CountdownTimer.tsx
@@ -57,15 +57,17 @@ const CountdownTimer: FC<CountdownTimerProps> = ({ targetDate }) => {
     if (value === 0) {
       return '';
     }
-    return `${value}${label} `;
+    return `${value}${label}`;
   };
 
   return (
     <span>
-      {formatTimeValue(timeLeft.days, 'd')}
-      {formatTimeValue(timeLeft.hours, 'h')}
-      {formatTimeValue(timeLeft.minutes, 'm')}
-      {formatTimeValue(timeLeft.seconds, 's')}
+      {[
+        formatTimeValue(timeLeft.days, 'd'),
+        formatTimeValue(timeLeft.hours, 'h'),
+        formatTimeValue(timeLeft.minutes, 'm'),
+        formatTimeValue(timeLeft.seconds, 's')
+      ].join(' ')}
     </span>
   );
 };

--- a/apps/web/src/components/Shared/CountdownTimer.tsx
+++ b/apps/web/src/components/Shared/CountdownTimer.tsx
@@ -66,7 +66,7 @@ const CountdownTimer: FC<CountdownTimerProps> = ({ targetDate }) => {
         formatTimeValue(timeLeft.days, 'd'),
         formatTimeValue(timeLeft.hours, 'h'),
         formatTimeValue(timeLeft.minutes, 'm'),
-        formatTimeValue(timeLeft.seconds, 's')
+        formatTimeValue(timeLeft.seconds, 's') || '0s'
       ].join(' ')}
     </span>
   );

--- a/apps/web/src/components/Shared/ProtectProfile.tsx
+++ b/apps/web/src/components/Shared/ProtectProfile.tsx
@@ -37,16 +37,15 @@ const ProtectProfile: FC = () => {
     }
   });
 
-  if (profileGuardianInformation.isProtected) {
+  const { isProtected, disablingProtectionTimestamp } =
+    profileGuardianInformation;
+
+  if (isProtected) {
     return null;
   }
 
-  const coolOffDate =
-    profileGuardianInformation.disablingProtectionTimestamp as any;
-  const coolOffTime = new Date(
-    new Date(coolOffDate).getTime() + 5 * 60 * 100
-  ).toISOString();
-  const isCoolOffPassed = new Date(coolOffDate).getTime() < Date.now();
+  const coolOffDate = new Date(disablingProtectionTimestamp);
+  const isCoolOffPassed = coolOffDate.getTime() < Date.now();
 
   return (
     <div className="border-b border-red-300 bg-red-500/20">
@@ -75,15 +74,16 @@ const ProtectProfile: FC = () => {
                 Your profile protection disabling has been triggered. It will
                 take effect in{' '}
                 <b>
-                  <CountdownTimer targetDate={coolOffTime} />
+                  <CountdownTimer targetDate={disablingProtectionTimestamp} />
                 </b>
+                .
               </Trans>
             )}
           </div>
         </GridItemEight>
         <GridItemFour className="mt-5 flex items-center sm:ml-auto sm:mt-0">
           {data?.hash ? (
-            <IndexStatus txHash={data?.hash} reload />
+            <IndexStatus txHash={data.hash} reload />
           ) : (
             <Button
               disabled={isLoading}

--- a/apps/web/src/components/Shared/ProtectProfile.tsx
+++ b/apps/web/src/components/Shared/ProtectProfile.tsx
@@ -61,7 +61,7 @@ const ProtectProfile: FC = () => {
           <div className="text-red-500">
             {isCoolOffPassed ? (
               <Trans>
-                Your profile protection disabled.
+                Your profile protection is disabled.
                 <Link
                   className="ml-1.5 underline"
                   href="https://github.com/lens-protocol/LIPs/blob/main/LIPs/lip-4.md"

--- a/apps/web/src/store/profile-guardian-information.ts
+++ b/apps/web/src/store/profile-guardian-information.ts
@@ -1,17 +1,14 @@
 import { create } from 'zustand';
 
+type ProfileGuardianInformationType =
+  | { isProtected: true; disablingProtectionTimestamp: null }
+  | { isProtected: false; disablingProtectionTimestamp: string };
+
 interface ProfileGuardianInformationState {
-  profileGuardianInformation: {
-    isProtected: boolean;
-    disablingProtectionTimestamp: number | null | undefined;
-  };
-  setProfileGuardianInformation: ({
-    isProtected,
-    disablingProtectionTimestamp
-  }: {
-    isProtected: boolean;
-    disablingProtectionTimestamp: number | null | undefined;
-  }) => void;
+  profileGuardianInformation: ProfileGuardianInformationType;
+  setProfileGuardianInformation: (
+    profileGuardianInformation: ProfileGuardianInformationType
+  ) => void;
   resetProfileGuardianInformation: () => void;
 }
 
@@ -21,15 +18,11 @@ export const useProfileGuardianInformationStore =
       isProtected: true,
       disablingProtectionTimestamp: null
     },
-    setProfileGuardianInformation: ({
-      isProtected,
-      disablingProtectionTimestamp
-    }) =>
+    setProfileGuardianInformation: (
+      profileGuardianInformation: ProfileGuardianInformationType
+    ) =>
       set(() => ({
-        profileGuardianInformation: {
-          isProtected,
-          disablingProtectionTimestamp
-        }
+        profileGuardianInformation
       })),
     resetProfileGuardianInformation: () =>
       set(() => ({


### PR DESCRIPTION
## What does this PR do?

This PR fixes typos, countdown logic, and countdown display related to the profile guardian mechanic.

## Related issues

Fixes #3800
Fixes #3801 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bad0361</samp>

*  Update the text and countdown timer in the `GuardianSettings` and `ProtectProfile` components to reflect the new security cooldown period of 5 minutes ([link](https://github.com/heyxyz/hey/pull/3899/files?diff=unified&w=0#diff-7c93d329c665824b282d39c9a9a417223094b14938f2f1e27a541666a4c7b11fL84-R85), [link](https://github.com/heyxyz/hey/pull/3899/files?diff=unified&w=0#diff-6958c1c8be1cc974484a9cb8ecd88982088cc93561d62448760477d83f845056L78-R79))
*  Refactor and simplify the code in the `ProtectProfile` component to use destructuring assignment, optional chaining, and direct access to the `disablingProtectionTimestamp` property ([link](https://github.com/heyxyz/hey/pull/3899/files?diff=unified&w=0#diff-6958c1c8be1cc974484a9cb8ecd88982088cc93561d62448760477d83f845056L40-R48), [link](https://github.com/heyxyz/hey/pull/3899/files?diff=unified&w=0#diff-6958c1c8be1cc974484a9cb8ecd88982088cc93561d62448760477d83f845056L86-R86))
*  Modify the `CountdownTimer` component to display a zero second value and add spaces between the time units for readability ([link](https://github.com/heyxyz/hey/pull/3899/files?diff=unified&w=0#diff-212190824bab5d0a641018371f33df1d7417e2543c86a77d0d5a9b72dac71fd5L60-R70))
*  Correct the grammar and punctuation in the text of the `ProtectProfile` component ([link](https://github.com/heyxyz/hey/pull/3899/files?diff=unified&w=0#diff-6958c1c8be1cc974484a9cb8ecd88982088cc93561d62448760477d83f845056L64-R63), [link](https://github.com/heyxyz/hey/pull/3899/files?diff=unified&w=0#diff-6958c1c8be1cc974484a9cb8ecd88982088cc93561d62448760477d83f845056L78-R79))
*  Change the `ProfileGuardianInformationState` interface and the `setProfileGuardianInformation` function to use a union type for the `profileGuardianInformation` property, instead of optional or nullable types, to enforce the invariant and avoid type errors ([link](https://github.com/heyxyz/hey/pull/3899/files?diff=unified&w=0#diff-6fa155b9c76fca5bbee34fc39898d857e3b16083504888808e7c291f7bc7342dL3-R11), [link](https://github.com/heyxyz/hey/pull/3899/files?diff=unified&w=0#diff-6fa155b9c76fca5bbee34fc39898d857e3b16083504888808e7c291f7bc7342dL24-R25))

## Emoji

<!--
copilot:emoji
-->

🚀🕒♻️

<!--
1.  🚀 - This emoji can be used to indicate a feature enhancement or improvement, such as making the security cooldown period shorter and more user-friendly.
2.  🕒 - This emoji can be used to indicate a change related to time or timers, such as modifying the countdown timer component to display zero seconds and add spaces between the time units.
3.  ♻️ - This emoji can be used to indicate a code refactor or cleanup, such as simplifying the `ProtectProfile` component and its subcomponents, fixing grammatical and punctuation errors, and improving the type safety and readability of the code.
-->

## Proof


<img width="1148" alt="Screenshot 2023-10-08 at 21 39 15" src="https://github.com/heyxyz/hey/assets/7318830/246edafa-1b52-49ed-af67-972eb1c309aa">

<img width="1104" alt="Screenshot 2023-10-08 at 21 42 46" src="https://github.com/heyxyz/hey/assets/7318830/48449c1f-94d8-4647-a5c5-d08b5ec66921">


