### PR TITLE
fix: 🐛 scroll to main thread post on page load

### DIFF
--- a/apps/web/src/components/Publication/FullPublication.tsx
+++ b/apps/web/src/components/Publication/FullPublication.tsx
@@ -1,7 +1,7 @@
 import type { Publication } from '@hey/lens';
 import getAppName from '@hey/lib/getAppName';
 import { formatDate, formatTime } from '@lib/formatTime';
-import type { FC } from 'react';
+import type { FC, LegacyRef } from 'react';
 
 import PublicationActions from './Actions';
 import FeaturedGroup from './FeaturedGroup';
@@ -14,6 +14,11 @@ import PublicationType from './Type';
 interface FullPublicationProps {
   publication: Publication;
 }
+
+// Define an explicit function to ensure
+// reference stability between renders.
+const scrollToPostRef: LegacyRef<HTMLDivElement> = (element) =>
+  element?.scrollIntoView();
 
 const FullPublication: FC<FullPublicationProps> = ({ publication }) => {
   const isMirror = publication.__typename === 'Mirror';
@@ -36,7 +41,7 @@ const FullPublication: FC<FullPublicationProps> = ({ publication }) => {
   return (
     <article className="p-5" data-testid={`publication-${publication.id}`}>
       <PublicationType publication={publication} showType />
-      <div>
+      <div className="scroll-mt-14 sm:scroll-mt-16" ref={scrollToPostRef}>
         <PublicationHeader publication={publication} />
         <div className="ml-[53px]">
           {publication?.hidden ? (


### PR DESCRIPTION
## What does this PR do?

Adds functionality to scroll to the main thread post on page load.

## Related issues

Fixes #2555 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

Adds a [callback ref](https://react.dev/reference/react-dom/components/common#ref-callback) to the wrapping `div` to expose the underlying element so we can scroll to it. I also added [scroll-margin](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin) to account for the `Navbar` at the top of the application.

/claim #2555
