### PR TITLE
fix: scroll to main thread post on page load

### DIFF
--- a/apps/web/src/components/Publication/FullPublication.tsx
+++ b/apps/web/src/components/Publication/FullPublication.tsx
@@ -1,7 +1,7 @@
 import type { Publication } from '@hey/lens';
 import getAppName from '@hey/lib/getAppName';
 import { formatDate, formatTime } from '@lib/formatTime';
-import type { FC } from 'react';
+import type { FC, Ref } from 'react';
 
 import PublicationActions from './Actions';
 import FeaturedGroup from './FeaturedGroup';
@@ -13,9 +13,13 @@ import PublicationType from './Type';
 
 interface FullPublicationProps {
   publication: Publication;
+  mainPostRef: Ref<HTMLDivElement>;
 }
 
-const FullPublication: FC<FullPublicationProps> = ({ publication }) => {
+const FullPublication: FC<FullPublicationProps> = ({
+  publication,
+  mainPostRef
+}) => {
   const isMirror = publication.__typename === 'Mirror';
   const timestamp = isMirror
     ? publication?.mirrorOf?.createdAt
@@ -36,7 +40,7 @@ const FullPublication: FC<FullPublicationProps> = ({ publication }) => {
   return (
     <article className="p-5" data-testid={`publication-${publication.id}`}>
       <PublicationType publication={publication} showType />
-      <div>
+      <div className="scroll-mt-14 sm:scroll-mt-16" ref={mainPostRef}>
         <PublicationHeader publication={publication} />
         <div className="ml-[53px]">
           {publication?.hidden ? (

--- a/packages/ui/src/GridLayout.tsx
+++ b/packages/ui/src/GridLayout.tsx
@@ -1,4 +1,5 @@
-import type { FC, ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import { forwardRef } from 'react';
 
 import cn from '../cn';
 
@@ -8,39 +9,49 @@ interface GridProps {
   classNameChild?: string;
 }
 
-export const GridLayout: FC<GridProps> = ({
-  children,
-  className = '',
-  classNameChild = ''
-}) => {
-  return (
-    <div
-      className={cn(
-        'container mx-auto max-w-screen-xl grow px-0 pb-2 pt-8 sm:px-5',
-        className
-      )}
-    >
-      <div className={cn('grid grid-cols-12 lg:gap-8', classNameChild)}>
+export const GridLayout = forwardRef<HTMLDivElement, GridProps>(
+  ({ children, className = '', classNameChild = '' }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'container mx-auto max-w-screen-xl grow px-0 pb-2 pt-8 sm:px-5',
+          className
+        )}
+      >
+        <div className={cn('grid grid-cols-12 lg:gap-8', classNameChild)}>
+          {children}
+        </div>
+      </div>
+    );
+  }
+);
+
+export const GridItemFour = forwardRef<HTMLDivElement, GridProps>(
+  ({ children, className = '' }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn('col-span-12 md:col-span-12 lg:col-span-4', className)}
+      >
         {children}
       </div>
-    </div>
-  );
-};
+    );
+  }
+);
 
-export const GridItemFour: FC<GridProps> = ({ children, className = '' }) => {
-  return (
-    <div className={cn('col-span-12 md:col-span-12 lg:col-span-4', className)}>
-      {children}
-    </div>
-  );
-};
-
-export const GridItemEight: FC<GridProps> = ({ children, className = '' }) => {
-  return (
-    <div
-      className={cn('col-span-12 mb-5 md:col-span-12 lg:col-span-8', className)}
-    >
-      {children}
-    </div>
-  );
-};
+export const GridItemEight = forwardRef<HTMLDivElement, GridProps>(
+  ({ children, className = '' }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'col-span-12 mb-5 md:col-span-12 lg:col-span-8',
+          className
+        )}
+      >
+        {children}
+      </div>
+    );
+  }
+);


### PR DESCRIPTION
## What does this PR do?

Adds functionality to scroll to the main thread post on page load.

This is a second attempt at fixing this issue after https://github.com/heyxyz/hey/pull/3909 was closed. In case this PR doesn't properly handle every edge case, I'm happy to address any issues instead of closing it.

## Related issues

Fixes #2555 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

The PR adds a few refs so we can access the height of different parts of the page (e.g. thread section, main post, and profile section). With that information, we can increase the `height` property of the main section to include additional space to accommodate placing the main post at the top of the page.

Once we have the additional space, we can scroll the main post into view which will place it at the top of the page. If the publication type is just a `Post`, we're skipping the scroll because there are no additional sections above the content.

/claim #2555
