### PR TITLE
fix: Language popup shown off-screen

### DIFF
--- a/apps/web/src/components/Shared/Footer/Locale.tsx
+++ b/apps/web/src/components/Shared/Footer/Locale.tsx
@@ -5,12 +5,15 @@ import { MISCELLANEOUS } from '@hey/data/tracking';
 import cn from '@hey/ui/cn';
 import { Leafwatch } from '@lib/leafwatch';
 import { useLingui } from '@lingui/react';
-import type { FC } from 'react';
-import { useCallback } from 'react';
+import type { FC, RefCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { SUPPORTED_LOCALES } from 'src/i18n';
 import { usePreferencesStore } from 'src/store/preferences';
+import { useWindowSize } from 'usehooks-ts';
 
 import MenuTransition from '../MenuTransition';
+
+const COLLISION_PADDING = 10;
 
 const Locale: FC = () => {
   const { i18n } = useLingui();
@@ -28,8 +31,19 @@ const Locale: FC = () => {
     location.reload();
   }, []);
 
+  const { height: windowHeight } = useWindowSize();
+  const [menuPositionBottom, setMenuPositionBottom] = useState(0);
+
+  const dropdownRef: RefCallback<HTMLElement> = useCallback((node) => {
+    if (node !== null) {
+      setMenuPositionBottom(node.getBoundingClientRect().bottom);
+    }
+  }, []);
+
+  const collision = menuPositionBottom > windowHeight - COLLISION_PADDING;
+
   return (
-    <Menu as="span">
+    <Menu as="span" className="relative">
       <Menu.Button
         className="inline-flex items-center space-x-1"
         data-testid="locale-selector"
@@ -40,7 +54,11 @@ const Locale: FC = () => {
       <MenuTransition>
         <Menu.Items
           static
-          className="absolute mt-2 rounded-xl border bg-white py-1 shadow-sm focus:outline-none dark:border-gray-700 dark:bg-gray-900"
+          className={cn(
+            'absolute rounded-xl border bg-white py-1 shadow-sm focus:outline-none dark:border-gray-700 dark:bg-gray-900',
+            collision && 'bottom-full'
+          )}
+          ref={dropdownRef}
           data-testid="locale-selector-menu"
         >
           {Object.entries(locales).map(([localeCode, localeName]) => (

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -35,7 +35,7 @@ progress::-moz-progress-bar {
 }
 
 .menu-item {
-  @apply m-2 block cursor-pointer rounded-lg px-2 py-1.5 text-sm text-gray-700 dark:text-gray-200;
+  @apply m-2 block cursor-pointer whitespace-nowrap rounded-lg px-2 py-1.5 text-sm text-gray-700 dark:text-gray-200;
 }
 
 .text-brand {


### PR DESCRIPTION
## What does this PR do?

Fixes language menu expanding below screen height. Handles window resizes but not scrolling. Rerendering on scroll needs to be heavily optimized to be performant. It's not strictly necessary here: Hiding parts of a menu by scrolling _away from it_ is an intuitive expected behavior.

## Related issues

Fixes #3770 
/claim #3770 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7667fac</samp>

* Import and use React types and hooks to handle menu position and window size ([link](https://github.com/heyxyz/hey/pull/3918/files?diff=unified&w=0#diff-2d9af24d277e24d0e5b89b5e09bf7745dd1a4c55b9630b816484d0319313cacbL8-R17))
* Define constants and functions to detect and avoid menu collision with window edge ([link](https://github.com/heyxyz/hey/pull/3918/files?diff=unified&w=0#diff-2d9af24d277e24d0e5b89b5e09bf7745dd1a4c55b9630b816484d0319313cacbL31-R46), [link](https://github.com/heyxyz/hey/pull/3918/files?diff=unified&w=0#diff-2d9af24d277e24d0e5b89b5e09bf7745dd1a4c55b9630b816484d0319313cacbL43-R61))
* Add `ref` attribute and conditional class name to `Menu.Items` component in `Locale.tsx` ([link](https://github.com/heyxyz/hey/pull/3918/files?diff=unified&w=0#diff-2d9af24d277e24d0e5b89b5e09bf7745dd1a4c55b9630b816484d0319313cacbL43-R61))

## Emoji

<!--
copilot:emoji
-->

🌐📱🎨

<!--
1.  🌐 - This emoji represents the locale menu and its functionality, as well as the internationalization aspect of the project.
2.  📱 - This emoji represents the responsiveness and usability of the menu on different devices and screen sizes, as well as the use of React hooks and types to handle the menu logic.
3.  🎨 - This emoji represents the styling and layout changes of the menu, such as moving the class to the local file and adding the utility class.
-->

## Video 

https://github.com/heyxyz/hey/assets/7318830/3a2b8d7b-34b6-4555-9bfa-2d984fa72ef0


