### PR TITLE
fix: handle wrong network for ProtectProfile

### DIFF
--- a/apps/web/src/components/Shared/ProtectProfile.tsx
+++ b/apps/web/src/components/Shared/ProtectProfile.tsx
@@ -14,6 +14,7 @@ import { Leafwatch } from '@lib/leafwatch';
 import { Trans } from '@lingui/macro';
 import Link from 'next/link';
 import type { FC } from 'react';
+import useHandleWrongNetwork from 'src/hooks/useHandleWrongNetwork';
 import { useProfileGuardianInformationStore } from 'src/store/profile-guardian-information';
 import { useContractWrite } from 'wagmi';
 
@@ -21,6 +22,8 @@ import CountdownTimer from './CountdownTimer';
 import IndexStatus from './IndexStatus';
 
 const ProtectProfile: FC = () => {
+  const handleWrongNetwork = useHandleWrongNetwork();
+
   const profileGuardianInformation = useProfileGuardianInformationStore(
     (state) => state.profileGuardianInformation
   );
@@ -94,7 +97,13 @@ const ProtectProfile: FC = () => {
                   <LockClosedIcon className="h-5 w-5" />
                 )
               }
-              onClick={() => write()}
+              onClick={() => {
+                if (handleWrongNetwork()) {
+                  return;
+                }
+
+                write();
+              }}
             >
               <Trans>Protect now</Trans>
             </Button>


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 56a92a8</samp>

Added network check for profile protection. The file `ProtectProfile.tsx` now uses a custom hook and a function to verify that the user is on the right Ethereum network before allowing them to protect their profile with a smart contract.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 56a92a8</samp>

* Import and use `useHandleWrongNetwork` hook to check and handle wrong Ethereum network connection ([link](https://github.com/heyxyz/hey/pull/3931/files?diff=unified&w=0#diff-6958c1c8be1cc974484a9cb8ecd88982088cc93561d62448760477d83f845056R17), [link](https://github.com/heyxyz/hey/pull/3931/files?diff=unified&w=0#diff-6958c1c8be1cc974484a9cb8ecd88982088cc93561d62448760477d83f845056R25-R26), [link](https://github.com/heyxyz/hey/pull/3931/files?diff=unified&w=0#diff-6958c1c8be1cc974484a9cb8ecd88982088cc93561d62448760477d83f845056L97-R106))

## Emoji

<!--
copilot:emoji
-->

🛡️🔌🧭

<!--
1.  🛡️ - This emoji represents the protection of the user's profile and the security aspect of the custom hook and function.
2.  🔌 - This emoji represents the connection to the Ethereum network and the detection of the network change events.
3.  🧭 - This emoji represents the guidance and feedback that the function provides to the user if they are on the wrong network or need to switch networks.
-->
