### PR TITLE
Added Livepeer to known iframe sites

### DIFF
--- a/packages/workers/oembed/src/helper/meta/generateIframe.ts
+++ b/packages/workers/oembed/src/helper/meta/generateIframe.ts
@@ -4,7 +4,8 @@ const knownSites = [
   'tape.xyz',
   'open.spotify.com',
   'soundcloud.com',
-  'oohlala.xyz'
+  'oohlala.xyz',
+  'lvpr.tv'
 ];
 
 const pickUrlSites = ['open.spotify.com'];


### PR DESCRIPTION
## What does this PR do?

Added Livepeer URL to known sites for embedded iframe livestreams.

## Explanation of the changes

[Livepeer](https://github.com/livepeer) needs to be allowed to display an iframe URL of the video content to allow viewing of livestreams and video from the Livepeer network.

While building a Lens Livestreaming Application called [Waves](https://github.com/GageVanK/Waves-Lens) we ran into this issue of cross streaming video to [Hey.xyz](https://github.com/heyxyz)
