### PR TITLE
cleanup: remove unwanted node_compat on cf workers

### DIFF
--- a/packages/workers/features/wrangler.toml
+++ b/packages/workers/features/wrangler.toml
@@ -2,7 +2,6 @@ name = "features"
 main = "src/index.ts"
 compatibility_date = "2023-10-25"
 keep_vars = true
-node_compat = true
 
 routes = [
 	{ pattern = "features.hey.xyz", custom_domain = true }

--- a/packages/workers/feeds/wrangler.toml
+++ b/packages/workers/feeds/wrangler.toml
@@ -2,7 +2,6 @@ name = "feeds"
 main = "src/index.ts"
 compatibility_date = "2023-10-25"
 keep_vars = true
-node_compat = true
 
 routes = [
 	{ pattern = "feeds.hey.xyz", custom_domain = true }

--- a/packages/workers/groups/wrangler.toml
+++ b/packages/workers/groups/wrangler.toml
@@ -2,7 +2,6 @@ name = "groups"
 main = "src/index.ts"
 compatibility_date = "2023-10-25"
 keep_vars = true
-node_compat = true
 
 routes = [
 	{ pattern = "groups.hey.xyz", custom_domain = true }

--- a/packages/workers/leafwatch/wrangler.toml
+++ b/packages/workers/leafwatch/wrangler.toml
@@ -2,7 +2,6 @@ name = "leafwatch"
 main = "src/index.ts"
 compatibility_date = "2023-10-25"
 keep_vars = true
-node_compat = true
 
 routes = [
 	{ pattern = "leafwatch.hey.xyz", custom_domain = true }

--- a/packages/workers/live/wrangler.toml
+++ b/packages/workers/live/wrangler.toml
@@ -2,7 +2,6 @@ name = "live"
 main = "src/index.ts"
 compatibility_date = "2023-10-25"
 keep_vars = true
-node_compat = true
 
 routes = [
 	{ pattern = "live.hey.xyz", custom_domain = true }

--- a/packages/workers/live/wrangler.toml
+++ b/packages/workers/live/wrangler.toml
@@ -7,9 +7,6 @@ routes = [
 	{ pattern = "live.hey.xyz", custom_domain = true }
 ]
 
-[placement]
-mode = "smart"
-
 [env.production.vars]
 RELEASE = ""
 LIVEPEER_API_KEY = ""

--- a/packages/workers/metadata/wrangler.toml
+++ b/packages/workers/metadata/wrangler.toml
@@ -7,9 +7,6 @@ routes = [
 	{ pattern = "metadata.hey.xyz", custom_domain = true }
 ]
 
-[placement]
-mode = "smart"
-
 [env.production.vars]
 RELEASE = ""
 IRYS_PRIVATE_KEY = ""

--- a/packages/workers/metadata/wrangler.toml
+++ b/packages/workers/metadata/wrangler.toml
@@ -2,7 +2,6 @@ name = "metadata"
 main = "src/index.ts"
 compatibility_date = "2023-10-25"
 keep_vars = true
-node_compat = true
 
 routes = [
 	{ pattern = "metadata.hey.xyz", custom_domain = true }

--- a/packages/workers/preferences/wrangler.toml
+++ b/packages/workers/preferences/wrangler.toml
@@ -2,7 +2,6 @@ name = "preferences"
 main = "src/index.ts"
 compatibility_date = "2023-10-25"
 keep_vars = true
-node_compat = true
 
 routes = [
 	{ pattern = "preferences.hey.xyz", custom_domain = true }

--- a/packages/workers/pro/wrangler.toml
+++ b/packages/workers/pro/wrangler.toml
@@ -2,7 +2,6 @@ name = "pro"
 main = "src/index.ts"
 compatibility_date = "2023-10-25"
 keep_vars = true
-node_compat = true
 
 routes = [
 	{ pattern = "pro.hey.xyz", custom_domain = true }

--- a/packages/workers/snapshot-relay/wrangler.toml
+++ b/packages/workers/snapshot-relay/wrangler.toml
@@ -2,7 +2,6 @@ name = "snapshot-relay"
 main = "src/index.ts"
 compatibility_date = "2023-10-25"
 keep_vars = true
-node_compat = true
 
 routes = [
 	{ pattern = "snapshot-relay.hey.xyz", custom_domain = true }

--- a/packages/workers/staff-picks/wrangler.toml
+++ b/packages/workers/staff-picks/wrangler.toml
@@ -2,7 +2,6 @@ name = "staff-picks"
 main = "src/index.ts"
 compatibility_date = "2023-10-25"
 keep_vars = true
-node_compat = true
 
 routes = [
 	{ pattern = "staff-picks.hey.xyz", custom_domain = true }

--- a/packages/workers/stats/wrangler.toml
+++ b/packages/workers/stats/wrangler.toml
@@ -2,7 +2,6 @@ name = "stats"
 main = "src/index.ts"
 compatibility_date = "2023-10-25"
 keep_vars = true
-node_compat = true
 
 routes = [
 	{ pattern = "stats.hey.xyz", custom_domain = true }

--- a/packages/workers/stats/wrangler.toml
+++ b/packages/workers/stats/wrangler.toml
@@ -7,9 +7,6 @@ routes = [
 	{ pattern = "stats.hey.xyz", custom_domain = true }
 ]
 
-[placement]
-mode = "smart"
-
 [env.production.vars]
 RELEASE = ""
 CLICKHOUSE_PASSWORD = ""


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b3b4e07</samp>

Removed the `node_compat` option from the `wrangler.toml` files of all workers in the `packages/workers` directory. This option is unnecessary as none of the workers use Node.js modules.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b3b4e07</samp>

*  Remove `node_compat` option from `wrangler.toml` files of 10 workers ([link](https://github.com/heyxyz/hey/pull/3999/files?diff=unified&w=0#diff-6c0ea0487485b81f19e4bbf1a527a413e9a5ecb871e7a95f97c03ed001bbd09fL5), [link](https://github.com/heyxyz/hey/pull/3999/files?diff=unified&w=0#diff-a2a445db744e4afab79f6dee1135b01cb427d5d39cbc486d59f4dab325e90b07L5), [link](https://github.com/heyxyz/hey/pull/3999/files?diff=unified&w=0#diff-db5971fce9453c500d3ed7c431f2fc475c2d41766b988738b2a75976e2a83030L5), [link](https://github.com/heyxyz/hey/pull/3999/files?diff=unified&w=0#diff-1e3e0b7e62f1f77213d03f912edce1d8f44ef56bb473e2378420a35e79004d9bL5), [link](https://github.com/heyxyz/hey/pull/3999/files?diff=unified&w=0#diff-586f2382f771cfb0388a564a6c9566726af341fc844389377e17379053c2c6b5L5), [link](https://github.com/heyxyz/hey/pull/3999/files?diff=unified&w=0#diff-1155a7f6231fa0bb8235ed5b55c3dde070a7015f590374ed395945bd7977426fL5), [link](https://github.com/heyxyz/hey/pull/3999/files?diff=unified&w=0#diff-35dfb86843e19a7212cf7021c4f1b18fd2081d01c213f73e9a6b9a5ab02b97f1L5), [link](https://github.com/heyxyz/hey/pull/3999/files?diff=unified&w=0#diff-8cd23a4e399993ba92a15480c8169de0c83e5092fb0bb7071f47552970551febL5), [link](https://github.com/heyxyz/hey/pull/3999/files?diff=unified&w=0#diff-b50cd529b47afe32c9c1db44aede01783ac2a2a6acb77aebc96f98f631cd0f7cL5), [link](https://github.com/heyxyz/hey/pull/3999/files?diff=unified&w=0#diff-106ea0b73aa28286c992b0d8f713524c3b96cc6da6ca570b53db9c8be0a11559L5), [link](https://github.com/heyxyz/hey/pull/3999/files?diff=unified&w=0#diff-fb01e09b0b7ad8fd8595235bd57bcaf0757c3c52e71e568b2037fae8dde0fffaL5)). This option is unnecessary as none of the workers use Node.js dependencies. The workers are `features`, `feeds`, `groups`, `leafwatch`, `live`, `metadata`, `preferences`, `pro`, `snapshot-relay`, and `staff-picks`.

## Emoji

<!--
copilot:emoji
-->

🧹🚀🌐

<!--
1.  🧹 This emoji represents cleaning or tidying up, which is what removing unnecessary options from the configuration files does.
2.  🚀 This emoji represents launching or deploying, which is what the `wrangler.toml` files are used for when publishing the workers to Cloudflare.
3.  🌐 This emoji represents the web or the internet, which is the domain of the workers and their functionality.
-->
