### PR TITLE
fix(perf): user sig nonce call

### DIFF
--- a/apps/web/src/components/Common/Layout.tsx
+++ b/apps/web/src/components/Common/Layout.tsx
@@ -12,6 +12,7 @@ import { Toaster } from 'react-hot-toast';
 import { useAppStore } from 'src/store/useAppStore';
 import { hydrateAuthTokens, signOut } from 'src/store/useAuthPersistStore';
 import { useFeatureFlagsStore } from 'src/store/useFeatureFlagsStore';
+import { useNonceStore } from 'src/store/useNonceStore';
 import { usePreferencesStore } from 'src/store/usePreferencesStore';
 import { useProStore } from 'src/store/useProStore';
 import { useEffectOnce, useIsMounted } from 'usehooks-ts';
@@ -41,6 +42,9 @@ const Layout: FC<LayoutProps> = ({ children }) => {
   const resetFeatureFlags = useFeatureFlagsStore(
     (state) => state.resetFeatureFlags
   );
+  const setLensHubOnchainSigNonce = useNonceStore(
+    (state) => state.setLensHubOnchainSigNonce
+  );
   const loadingPro = useProStore((state) => state.loadingPro);
   const resetPro = useProStore((state) => state.resetPro);
 
@@ -61,8 +65,9 @@ const Layout: FC<LayoutProps> = ({ children }) => {
   const { loading } = useCurrentProfileQuery({
     variables: { request: { forProfileId: sessionProfileId } },
     skip: !sessionProfileId || isAddress(sessionProfileId),
-    onCompleted: ({ profile }) => {
+    onCompleted: ({ profile, userSigNonces }) => {
       setCurrentProfile(profile as Profile);
+      setLensHubOnchainSigNonce(userSigNonces.lensHubOnchainSigNonce);
     }
   });
 

--- a/apps/web/src/components/Common/Providers/LensSubscriptionsProvider.tsx
+++ b/apps/web/src/components/Common/Providers/LensSubscriptionsProvider.tsx
@@ -104,12 +104,11 @@ const LensSubscriptionsProvider: FC = () => {
 
   useUserSigNoncesQuery({
     onCompleted: (data) => {
-      setLensHubOnchainSigNonce(data.userSigNonces.lensHubOnchainSigNonce);
       setLensPublicActProxyOnchainSigNonce(
         data.userSigNonces.lensPublicActProxyOnchainSigNonce
       );
     },
-    skip: !sessionProfileId
+    skip: Boolean(sessionProfileId) ? !isAddress(sessionProfileId) : true
   });
 
   // Sync zustand stores between tabs

--- a/packages/lens/documents/fragments/UserSigNoncesFields.graphql
+++ b/packages/lens/documents/fragments/UserSigNoncesFields.graphql
@@ -1,4 +1,0 @@
-fragment UserSigNoncesFields on UserSigNonces {
-  lensHubOnchainSigNonce
-  lensPublicActProxyOnchainSigNonce
-}

--- a/packages/lens/documents/queries/CurrentProfile.graphql
+++ b/packages/lens/documents/queries/CurrentProfile.graphql
@@ -6,4 +6,7 @@ query CurrentProfile($request: ProfileRequest!) {
       cooldownEndsOn
     }
   }
+  userSigNonces {
+    lensHubOnchainSigNonce
+  }
 }

--- a/packages/lens/documents/queries/UserSigNonces.graphql
+++ b/packages/lens/documents/queries/UserSigNonces.graphql
@@ -1,5 +1,5 @@
 query UserSigNonces {
   userSigNonces {
-    ...UserSigNoncesFields
+    lensPublicActProxyOnchainSigNonce
   }
 }

--- a/packages/lens/documents/subscriptions/UserSigNoncesSubscription.graphql
+++ b/packages/lens/documents/subscriptions/UserSigNoncesSubscription.graphql
@@ -1,5 +1,6 @@
 subscription UserSigNoncesSubscription($address: EvmAddress!) {
   userSigNonces(address: $address) {
-    ...UserSigNoncesFields
+    lensHubOnchainSigNonce
+    lensPublicActProxyOnchainSigNonce
   }
 }


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f8c041a</samp>

This pull request adds and manages the user's signature nonces for the LensHub contract in the web app. It modifies the `Layout`, `LensSubscriptionsProvider`, `CurrentProfile`, `UserSigNonces`, and `UserSigNoncesSubscription` files to fetch, update, and use the signature nonces for the LensHub contract.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f8c041a</samp>

*  Add and synchronize the user's signature nonce for the LensHub contract ([link](https://github.com/heyxyz/hey/pull/4006/files?diff=unified&w=0#diff-0e16eaa722dcbe43f850552755cc5fafac704a32a39761450c6d2edf5a91a637R15), [link](https://github.com/heyxyz/hey/pull/4006/files?diff=unified&w=0#diff-0e16eaa722dcbe43f850552755cc5fafac704a32a39761450c6d2edf5a91a637R45-R47), [link](https://github.com/heyxyz/hey/pull/4006/files?diff=unified&w=0#diff-0e16eaa722dcbe43f850552755cc5fafac704a32a39761450c6d2edf5a91a637L64-R70), [link](https://github.com/heyxyz/hey/pull/4006/files?diff=unified&w=0#diff-02c62b269bb17ee03e306dc67afec62f4e53cffe1bf53285d89954906173a563R9-R11), [link](https://github.com/heyxyz/hey/pull/4006/files?diff=unified&w=0#diff-3e38f1e98258bd299e6e9f6996724e95939c515e85990523636007eca25a2cadL3-R4))
  - Import the `useNonceStore` hook in `Layout.tsx` to access and update the nonce state ([link](https://github.com/heyxyz/hey/pull/4006/files?diff=unified&w=0#diff-0e16eaa722dcbe43f850552755cc5fafac704a32a39761450c6d2edf5a91a637R15))
  - Define a function `setLensHubOnchainSigNonce` in `Layout.tsx` to update the nonce state for the LensHub contract ([link](https://github.com/heyxyz/hey/pull/4006/files?diff=unified&w=0#diff-0e16eaa722dcbe43f850552755cc5fafac704a32a39761450c6d2edf5a91a637R45-R47))
  - Include the `userSigNonces` field in the `useCurrentProfileQuery` hook result in `Layout.tsx` and call `setLensHubOnchainSigNonce` with the `userSigNonces.lensHubOnchainSigNonce` value in the `onCompleted` callback ([link](https://github.com/heyxyz/hey/pull/4006/files?diff=unified&w=0#diff-0e16eaa722dcbe43f850552755cc5fafac704a32a39761450c6d2edf5a91a637L64-R70))
  - Add the `userSigNonces` field to the `CurrentProfile` query in `CurrentProfile.graphql` to fetch the nonce data from the server ([link](https://github.com/heyxyz/hey/pull/4006/files?diff=unified&w=0#diff-02c62b269bb17ee03e306dc67afec62f4e53cffe1bf53285d89954906173a563R9-R11))
  - Add the `lensHubOnchainSigNonce` field to the `UserSigNoncesSubscription` subscription in `UserSigNoncesSubscription.graphql` to subscribe to the nonce updates from the server ([link](https://github.com/heyxyz/hey/pull/4006/files?diff=unified&w=0#diff-3e38f1e98258bd299e6e9f6996724e95939c515e85990523636007eca25a2cadL3-R4))
* Remove the redundant call to `setLensHubOnchainSigNonce` and modify the `skip` condition in the `useUserSigNoncesQuery` hook in `LensSubscriptionsProvider.tsx` ([link](https://github.com/heyxyz/hey/pull/4006/files?diff=unified&w=0#diff-77b9a522067f84850b3de86aa77f1655c0b0b42980334869042d0fbe443b71fdL107-R111))
  - Remove the line that calls `setLensHubOnchainSigNonce` in the `onCompleted` callback, since it is already called in the `Layout` component ([link](https://github.com/heyxyz/hey/pull/4006/files?diff=unified&w=0#diff-77b9a522067f84850b3de86aa77f1655c0b0b42980334869042d0fbe443b71fdL107-R111))
  - Modify the `skip` condition to only query the nonce data if the `sessionProfileId` is a valid Ethereum address, since the nonce data is only relevant for Ethereum accounts ([link](https://github.com/heyxyz/hey/pull/4006/files?diff=unified&w=0#diff-77b9a522067f84850b3de86aa77f1655c0b0b42980334869042d0fbe443b71fdL107-R111))
* Reduce the amount of data fetched by the `UserSigNonces` query in `UserSigNonces.graphql` by removing the `...UserSigNoncesFields` fragment and only selecting the `lensPublicActProxyOnchainSigNonce` field ([link](https://github.com/heyxyz/hey/pull/4006/files?diff=unified&w=0#diff-88e2c40e9931ff03c4851b154f1765914092e4742edf40869552c7583f1e1a84L3-R3))
  - Remove the `...UserSigNoncesFields` fragment, since the other nonce fields are not needed by the `useUserSigNoncesQuery` hook in the `LensSubscriptionsProvider` component ([link](https://github.com/heyxyz/hey/pull/4006/files?diff=unified&w=0#diff-88e2c40e9931ff03c4851b154f1765914092e4742edf40869552c7583f1e1a84L3-R3))
  - Only select the `lensPublicActProxyOnchainSigNonce` field, which contains the user's signature nonce for the LensPublicActProxy contract, which is used to proxy the user's actions on Lens ([link](https://github.com/heyxyz/hey/pull/4006/files?diff=unified&w=0#diff-88e2c40e9931ff03c4851b154f1765914092e4742edf40869552c7583f1e1a84L3-R3))
* Delete the `UserSigNoncesFields` fragment in `UserSigNoncesFields.graphql`, since it is no longer used by any query or subscription ([link](https://github.com/heyxyz/hey/pull/4006/files?diff=unified&w=0#diff-97d422498f80a62b8cdd97e2bef72d5e949128ab19cc29e6cc7907b512ffad31))

## Emoji

<!--
copilot:emoji
-->

🪡📝🔐

<!--
1.  🪡 - This emoji represents the removal of the redundant line that calls the `setLensHubOnchainSigNonce` function in the `useUserSigNoncesQuery` hook. The emoji symbolizes sewing or stitching, which implies fixing or removing something unnecessary.
2.  📝 - This emoji represents the addition of the `userSigNonces` field to the `CurrentProfile` query and the `lensHubOnchainSigNonce` field to the `UserSigNoncesSubscription` subscription. The emoji symbolizes writing or editing, which implies adding or modifying something relevant.
3.  🔐 - This emoji represents the hook that manages the user's signature nonces for different contracts. The emoji symbolizes security or encryption, which implies protecting or verifying something sensitive.
-->
