### PR TITLE
feat: use new verified table

### DIFF
--- a/packages/supabase/database.types.ts
+++ b/packages/supabase/database.types.ts
@@ -202,6 +202,18 @@ export interface Database {
           }
         ];
       };
+      verified: {
+        Row: {
+          id: string;
+        };
+        Insert: {
+          id: string;
+        };
+        Update: {
+          id?: string;
+        };
+        Relationships: [];
+      };
     };
     Views: {
       [_ in never]: never;

--- a/packages/workers/features/src/constants.ts
+++ b/packages/workers/features/src/constants.ts
@@ -1,1 +1,0 @@
-export const VERIFIED_KV_KEY = 'verified-list';

--- a/packages/workers/features/src/constants.ts
+++ b/packages/workers/features/src/constants.ts
@@ -1,2 +1,1 @@
 export const VERIFIED_KV_KEY = 'verified-list';
-export const VERIFIED_FEATURE_ID = 'faa1a7ff-7826-4957-9224-7b3fbd145fde';

--- a/packages/workers/features/src/handlers/getVerified.ts
+++ b/packages/workers/features/src/handlers/getVerified.ts
@@ -1,7 +1,7 @@
 import response from '@hey/lib/response';
 import createSupabaseClient from '@hey/supabase/createSupabaseClient';
 
-import { VERIFIED_FEATURE_ID, VERIFIED_KV_KEY } from '../constants';
+import { VERIFIED_KV_KEY } from '../constants';
 import type { WorkerRequest } from '../types';
 
 export default async (request: WorkerRequest) => {
@@ -10,18 +10,13 @@ export default async (request: WorkerRequest) => {
 
     if (!cache) {
       const client = createSupabaseClient(request.env.SUPABASE_KEY);
-
-      const { data, error } = await client
-        .from('profile-features')
-        .select('*')
-        .eq('feature_id', VERIFIED_FEATURE_ID)
-        .eq('enabled', true);
+      const { data, error } = await client.from('verified').select('*');
 
       if (error) {
         throw error;
       }
 
-      const ids = data.map((item) => item.profile_id);
+      const ids = data.map((item) => item.id);
       await request.env.FEATURES.put(VERIFIED_KV_KEY, JSON.stringify(ids));
 
       return response({ success: true, result: ids });
@@ -29,6 +24,7 @@ export default async (request: WorkerRequest) => {
 
     return response({ success: true, fromKV: true, result: JSON.parse(cache) });
   } catch (error) {
+    console.error(error);
     throw error;
   }
 };

--- a/packages/workers/features/src/handlers/getVerified.ts
+++ b/packages/workers/features/src/handlers/getVerified.ts
@@ -1,12 +1,11 @@
 import response from '@hey/lib/response';
 import createSupabaseClient from '@hey/supabase/createSupabaseClient';
 
-import { VERIFIED_KV_KEY } from '../constants';
 import type { WorkerRequest } from '../types';
 
 export default async (request: WorkerRequest) => {
   try {
-    const cache = await request.env.FEATURES.get(VERIFIED_KV_KEY);
+    const cache = await request.env.VERIFIED.get('list');
 
     if (!cache) {
       const client = createSupabaseClient(request.env.SUPABASE_KEY);
@@ -17,7 +16,7 @@ export default async (request: WorkerRequest) => {
       }
 
       const ids = data.map((item) => item.id);
-      await request.env.FEATURES.put(VERIFIED_KV_KEY, JSON.stringify(ids));
+      await request.env.VERIFIED.put('list', JSON.stringify(ids));
 
       return response({ success: true, result: ids });
     }

--- a/packages/workers/features/src/types.ts
+++ b/packages/workers/features/src/types.ts
@@ -4,6 +4,7 @@ export interface Env {
   RELEASE: string;
   SUPABASE_KEY: string;
   FEATURES: KVNamespace;
+  VERIFIED: KVNamespace;
 }
 
 export type WorkerRequest = {

--- a/packages/workers/features/wrangler.toml
+++ b/packages/workers/features/wrangler.toml
@@ -8,7 +8,8 @@ routes = [
 ]
 
 kv_namespaces = [
-  { binding = "FEATURES", id = "7f319321a8b44003b99f9d41e1d7e065", preview_id = "7f319321a8b44003b99f9d41e1d7e065" }
+  { binding = "FEATURES", id = "7f319321a8b44003b99f9d41e1d7e065", preview_id = "7f319321a8b44003b99f9d41e1d7e065" },
+  { binding = "VERIFIED", id = "b73287bbf01249a5b6efbc529593f994", preview_id = "b73287bbf01249a5b6efbc529593f994" }
 ]
 
 [env.production.vars]

--- a/packages/workers/internal/src/constants.ts
+++ b/packages/workers/internal/src/constants.ts
@@ -1,4 +1,3 @@
-export const VERIFIED_KV_KEY = 'verified-list';
 export const STAFF_FEATURE_ID = 'eea3b2d2-a60c-4e41-8130-1cb34cc37810';
 export const STAFF_MODE_FEATURE_ID = '0e588583-b347-4752-9e1e-0ad4128348e8';
 export const GARDENER_FEATURE_ID = '0a441129-182a-4a3f-83cf-a13c5ad8282b';

--- a/packages/workers/internal/src/constants.ts
+++ b/packages/workers/internal/src/constants.ts
@@ -3,4 +3,3 @@ export const STAFF_FEATURE_ID = 'eea3b2d2-a60c-4e41-8130-1cb34cc37810';
 export const STAFF_MODE_FEATURE_ID = '0e588583-b347-4752-9e1e-0ad4128348e8';
 export const GARDENER_FEATURE_ID = '0a441129-182a-4a3f-83cf-a13c5ad8282b';
 export const GARDENER_MODE_FEATURE_ID = '9f66a465-e1d7-4123-b329-ddd14fd85510';
-export const VERIFIED_FEATURE_ID = 'faa1a7ff-7826-4957-9224-7b3fbd145fde';

--- a/packages/workers/internal/src/handlers/features/updateFeatureFlag.ts
+++ b/packages/workers/internal/src/handlers/features/updateFeatureFlag.ts
@@ -3,7 +3,6 @@ import response from '@hey/lib/response';
 import createSupabaseClient from '@hey/supabase/createSupabaseClient';
 import { boolean, object, string } from 'zod';
 
-import { VERIFIED_FEATURE_ID, VERIFIED_KV_KEY } from '../../constants';
 import validateIsStaff from '../../helpers/validateIsStaff';
 import type { WorkerRequest } from '../../types';
 
@@ -38,12 +37,6 @@ export default async (request: WorkerRequest) => {
   const { id, profile_id, enabled } = body as ExtensionRequest;
 
   const clearCache = async () => {
-    if (id === VERIFIED_FEATURE_ID) {
-      // Clear verified list cache in Cloudflare KV
-      await request.env.FEATURES.delete(VERIFIED_KV_KEY);
-    }
-
-    // Clear profile cache in Cloudflare KV
     await request.env.FEATURES.delete(`features:${profile_id}`);
   };
 

--- a/packages/workers/internal/src/handlers/features/updateGardenerMode.ts
+++ b/packages/workers/internal/src/handlers/features/updateGardenerMode.ts
@@ -40,7 +40,6 @@ export default async (request: WorkerRequest) => {
     const profile_id = payload.id;
 
     const clearCache = async () => {
-      // Clear profile cache in Cloudflare KV
       await request.env.FEATURES.delete(`features:${profile_id}`);
     };
 

--- a/packages/workers/internal/src/handlers/features/updateStaffMode.ts
+++ b/packages/workers/internal/src/handlers/features/updateStaffMode.ts
@@ -40,7 +40,6 @@ export default async (request: WorkerRequest) => {
     const profile_id = payload.id;
 
     const clearCache = async () => {
-      // Clear profile cache in Cloudflare KV
       await request.env.FEATURES.delete(`features:${profile_id}`);
     };
 

--- a/packages/workers/internal/src/handlers/verified/updateVerified.ts
+++ b/packages/workers/internal/src/handlers/verified/updateVerified.ts
@@ -1,0 +1,74 @@
+import { Errors } from '@hey/data/errors';
+import parseJwt from '@hey/lib/parseJwt';
+import response from '@hey/lib/response';
+import createSupabaseClient from '@hey/supabase/createSupabaseClient';
+import { boolean, object } from 'zod';
+
+import validateIsStaff from '../../helpers/validateIsStaff';
+import type { WorkerRequest } from '../../types';
+
+type ExtensionRequest = {
+  enabled: boolean;
+};
+
+const validationSchema = object({
+  enabled: boolean()
+});
+
+export default async (request: WorkerRequest) => {
+  const body = await request.json();
+  if (!body) {
+    return response({ success: false, error: Errors.NoBody });
+  }
+
+  const accessToken = request.headers.get('X-Access-Token');
+  const validation = validationSchema.safeParse(body);
+
+  if (!validation.success) {
+    return response({ success: false, error: validation.error.issues });
+  }
+
+  if (!(await validateIsStaff(request))) {
+    return response({ success: false, error: Errors.NotStaff });
+  }
+
+  const { enabled } = body as ExtensionRequest;
+
+  try {
+    const payload = parseJwt(accessToken as string);
+    const profile_id = payload.id;
+
+    const clearCache = async () => {
+      await request.env.VERIFIED.delete(`list`);
+    };
+
+    const client = createSupabaseClient(request.env.SUPABASE_KEY);
+
+    if (enabled) {
+      const { error: upsertError } = await client
+        .from('verified')
+        .upsert({ id: profile_id });
+
+      if (upsertError) {
+        throw upsertError;
+      }
+      await clearCache();
+
+      return response({ success: true, enabled });
+    }
+
+    const { error: deleteError } = await client
+      .from('verified')
+      .delete()
+      .eq('id', profile_id);
+
+    if (deleteError) {
+      throw deleteError;
+    }
+    await clearCache();
+
+    return response({ success: true, enabled });
+  } catch (error) {
+    throw error;
+  }
+};

--- a/packages/workers/internal/src/index.ts
+++ b/packages/workers/internal/src/index.ts
@@ -8,6 +8,7 @@ import updateFeatureFlag from './handlers/features/updateFeatureFlag';
 import updateGardenerMode from './handlers/features/updateGardenerMode';
 import updateStaffMode from './handlers/features/updateStaffMode';
 import downgradeProfiles from './handlers/pro/downgradeProfiles';
+import updateVerified from './handlers/verified/updateVerified';
 import buildRequest from './helpers/buildRequest';
 import type { Env, WorkerRequest } from './types';
 
@@ -28,6 +29,10 @@ featureRoutes
 const proRoutes = Router({ base: '/pro' });
 proRoutes.delete('/downgradeProfiles', downgradeProfiles);
 
+// Verified routes
+const verifiedRoutes = Router({ base: '/verified' });
+proRoutes.post('/updateVerified', validateLensAccount, updateVerified);
+
 // Main router
 const router = Router();
 router
@@ -41,6 +46,7 @@ router
   )
   .all('/feature/*', featureRoutes.handle)
   .all('/pro/*', proRoutes.handle)
+  .all('/verified/*', verifiedRoutes.handle)
   .all('*', () => error(404));
 
 export default {

--- a/packages/workers/internal/src/types.ts
+++ b/packages/workers/internal/src/types.ts
@@ -5,6 +5,7 @@ export interface Env {
   SUPABASE_KEY: string;
   SECRET: string;
   FEATURES: KVNamespace;
+  VERIFIED: KVNamespace;
 }
 
 export type WorkerRequest = {

--- a/packages/workers/internal/wrangler.toml
+++ b/packages/workers/internal/wrangler.toml
@@ -8,7 +8,8 @@ routes = [
 ]
 
 kv_namespaces = [
-  { binding = "FEATURES", id = "7f319321a8b44003b99f9d41e1d7e065", preview_id = "7f319321a8b44003b99f9d41e1d7e065" }
+  { binding = "FEATURES", id = "7f319321a8b44003b99f9d41e1d7e065", preview_id = "7f319321a8b44003b99f9d41e1d7e065" },
+  { binding = "VERIFIED", id = "b73287bbf01249a5b6efbc529593f994", preview_id = "b73287bbf01249a5b6efbc529593f994" }
 ]
 
 [env.production.vars]

--- a/packages/workers/preferences/src/handlers/updatePreferences.ts
+++ b/packages/workers/preferences/src/handlers/updatePreferences.ts
@@ -38,7 +38,6 @@ export default async (request: WorkerRequest) => {
     const client = createSupabaseClient(request.env.SUPABASE_KEY);
 
     const clearCache = async () => {
-      // Clear profile cache in Cloudflare KV
       await request.env.PREFERENCES.delete(`preferences:${payload.id}`);
     };
 


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c65a79c</samp>

This pull request refactors the verification feature across different workers and the Supabase database. It removes the dependency on the `profile-features` table and the Cloudflare KV cache, and uses a new `verified` table to store the verification status of profiles. It also updates and simplifies the handlers that interact with the verification feature.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c65a79c</samp>

*  Add a new table definition for `verified` to the `Database` interface in `database.types.ts` ([link](https://github.com/heyxyz/hey/pull/4008/files?diff=unified&w=0#diff-85d2d958072c93d3c902d2046ca9383f2c82e48ffa83e5b24d16458c47e351d9R205-R216))
*  Remove the constant `VERIFIED_FEATURE_ID` from the `features`, `internal`, and `profiles` workers, as it is no longer needed to query the `profile-features` table ([link](https://github.com/heyxyz/hey/pull/4008/files?diff=unified&w=0#diff-5be420ecce0ff24db17ec4053473f9fad68185f4ccb41e28aa6a9722cbdf1e8bL2), [link](https://github.com/heyxyz/hey/pull/4008/files?diff=unified&w=0#diff-3b5a64594fd411ea68a0774e35f147039124bcba59cb0241be02c4e1c25976d8L4-R4), [link](https://github.com/heyxyz/hey/pull/4008/files?diff=unified&w=0#diff-5c27e18cacc8d7f61f86ef551d2e808d77baf4115ca8ad2f5d8081806c13aa44L6), [link](https://github.com/heyxyz/hey/pull/4008/files?diff=unified&w=0#diff-e0a27cf27d335501ba7785981ba7989d341fea1c70a6e5aeb01aa85ce50779e1L6))
*  Modify the query logic in the `getVerified` handler in the `features` worker to fetch the data from the `verified` table instead of the `profile-features` table, and add a console error logging statement in case of a query error ([link](https://github.com/heyxyz/hey/pull/4008/files?diff=unified&w=0#diff-3b5a64594fd411ea68a0774e35f147039124bcba59cb0241be02c4e1c25976d8L13-R19), [link](https://github.com/heyxyz/hey/pull/4008/files?diff=unified&w=0#diff-3b5a64594fd411ea68a0774e35f147039124bcba59cb0241be02c4e1c25976d8R27))
*  Remove the logic to clear the cache of the verified list in the Cloudflare KV from the `updateFeatureFlag` handler in the `internal` worker, as it is no longer needed since the verification status is stored in the Supabase database ([link](https://github.com/heyxyz/hey/pull/4008/files?diff=unified&w=0#diff-e0a27cf27d335501ba7785981ba7989d341fea1c70a6e5aeb01aa85ce50779e1L41-L46))
*  Remove the comments to clear the profile cache in the Cloudflare KV from the `updateGardenerMode`, `updateStaffMode`, and `updatePreferences` handlers in the `internal` and `preferences` workers, as they are no longer relevant since the profile cache is cleared by a separate handler in the `profiles` worker ([link](https://github.com/heyxyz/hey/pull/4008/files?diff=unified&w=0#diff-0a47aad1754c28115d20e970db1be8bec3021cdf78903cf513fca10ecafcdda0L43), [link](https://github.com/heyxyz/hey/pull/4008/files?diff=unified&w=0#diff-e115aae74daa6403406c8a965393e077206b7852235f117ad6d94981d8f9665cL43), [link](https://github.com/heyxyz/hey/pull/4008/files?diff=unified&w=0#diff-9ad28b505e4e52fb43e1f4d57a25820a5a74593ce3e1d26ba4f0f920ce8003c5L41))

## Emoji

<!--
copilot:emoji
-->

🆕🔥🛠️

<!--
1.  🆕 for adding a new table definition for `verified` to the `Database` interface.
2.  🔥 for removing the constant `VERIFIED_FEATURE_ID` and the related cache clearing logic from the `features` and `internal` workers.
3.  🛠️ for updating and simplifying the `getVerified` and `updateFeatureFlag` handlers in the `features` worker.
-->
