### PR TITLE
feat: add support for sharingLink on LinkMetadataV3

### DIFF
--- a/apps/web/src/components/Publication/PublicationBody.tsx
+++ b/apps/web/src/components/Publication/PublicationBody.tsx
@@ -76,9 +76,16 @@ const PublicationBody: FC<PublicationBodyProps> = ({
   // Show poll
   const pollId = getPublicationAttribute(metadata.attributes, 'pollId');
   const showPoll = Boolean(pollId);
+  // Show sharing link
+  const showSharingLink = metadata.__typename === 'LinkMetadataV3';
   // Show oembed if no NFT, no attachments, no quoted publication
   const showOembed =
-    hasURLs && !showNft && !showLive && !showAttachments && !quoted;
+    !showSharingLink &&
+    hasURLs &&
+    !showNft &&
+    !showLive &&
+    !showAttachments &&
+    !quoted;
 
   // Remove URL at the end if oembed is there
   const onOembedData = (data: OG) => {
@@ -126,6 +133,13 @@ const PublicationBody: FC<PublicationBodyProps> = ({
           onData={onOembedData}
           publicationId={publication.id}
           url={urls[0]}
+        />
+      ) : null}
+      {metadata.__typename === 'LinkMetadataV3' ? (
+        <Oembed
+          onData={() => {}}
+          publicationId={publication.id}
+          url={metadata.sharingLink}
         />
       ) : null}
       {targetPublication.__typename === 'Quote' && (

--- a/packages/lens/documents/fragments/publication-metadata/LinkMetadataV3Fields.graphql
+++ b/packages/lens/documents/fragments/publication-metadata/LinkMetadataV3Fields.graphql
@@ -9,4 +9,5 @@ fragment LinkMetadataV3Fields on LinkMetadataV3 {
     ...PublicationMetadataMediaFields
   }
   content
+  sharingLink
 }


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ade51ef</samp>

This pull request adds support for a new type of publication metadata, `LinkMetadataV3`, which represents a sharing link generated by the hey app. It modifies the frontend component `PublicationBody` and the GraphQL fragment `LinkMetadataV3Fields` to handle and display the sharing link as a custom oembed.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at ade51ef</samp>

*  Prevent showing redundant previews for sharing links ([link](https://github.com/heyxyz/hey/pull/4103/files?diff=unified&w=0#diff-cf87c96f430fb044b052837b8732058bdc59aba03cba72f7f7c43143622ffae1L79-R88))
*  Render `Oembed` component for `LinkMetadataV3` type ([link](https://github.com/heyxyz/hey/pull/4103/files?diff=unified&w=0#diff-cf87c96f430fb044b052837b8732058bdc59aba03cba72f7f7c43143622ffae1R138-R144), [link](https://github.com/heyxyz/hey/pull/4103/files?diff=unified&w=0#diff-d63fff26f6db4ec9c67eb8a0756a062fa3fa11a4ba4caf60a561e8ab2f304097R12))
   *  Add `sharingLink` field to `LinkMetadataV3` fragment in `LinkMetadataV3Fields.graphql` ([link](https://github.com/heyxyz/hey/pull/4103/files?diff=unified&w=0#diff-d63fff26f6db4ec9c67eb8a0756a062fa3fa11a4ba4caf60a561e8ab2f304097R12))
   *  Pass `sharingLink` as URL prop to `Oembed` component in `PublicationBody.tsx` ([link](https://github.com/heyxyz/hey/pull/4103/files?diff=unified&w=0#diff-cf87c96f430fb044b052837b8732058bdc59aba03cba72f7f7c43143622ffae1R138-R144))

## Emoji

<!--
copilot:emoji
-->

:link::sparkles::wrench:

<!--
1.  :link: This emoji represents the concept of a sharing link and the new field added to the `LinkMetadataV3` fragment.
2.  :sparkles: This emoji represents the new feature of showing a custom oembed component for the sharing link, which enhances the user experience and adds some flair to the chat messages.
3.  :wrench: This emoji represents the logic and UI changes required to handle the new type of metadata and prevent showing duplicate oembeds.
-->
