### PR TITLE
fix: group and abuse removed from sidebar

### DIFF
--- a/apps/web/src/components/Staff/Sidebar.tsx
+++ b/apps/web/src/components/Staff/Sidebar.tsx
@@ -5,9 +5,7 @@ import {
   AdjustmentsHorizontalIcon,
   ClipboardIcon,
   CurrencyDollarIcon,
-  ExclamationTriangleIcon,
-  UserIcon,
-  UsersIcon
+  UserIcon
 } from '@heroicons/react/24/outline';
 
 const StaffSidebar: FC = () => {
@@ -26,11 +24,6 @@ const StaffSidebar: FC = () => {
             url: '/staff/users'
           },
           {
-            icon: <UsersIcon className="h-4 w-4" />,
-            title: 'Groups 🚧',
-            url: '/staff/groups'
-          },
-          {
             icon: <CurrencyDollarIcon className="h-4 w-4" />,
             title: 'Tokens',
             url: '/staff/tokens'
@@ -39,11 +32,6 @@ const StaffSidebar: FC = () => {
             icon: <AdjustmentsHorizontalIcon className="h-4 w-4" />,
             title: 'Feature flags',
             url: '/staff/feature-flags'
-          },
-          {
-            icon: <ExclamationTriangleIcon className="h-4 w-4" />,
-            title: 'Abuse 🚧',
-            url: '/staff/abuse'
           }
         ]}
       />


### PR DESCRIPTION
## What does this PR do?
Unused Groups and Abuse removed from sidebar

## Related issues

Fixes #4273

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
