### PR TITLE
fix: reduce padding-y on paid actions amount section

### DIFF
--- a/apps/web/src/components/Home/PaidActions/OpenActionPaidAction.tsx
+++ b/apps/web/src/components/Home/PaidActions/OpenActionPaidAction.tsx
@@ -56,7 +56,7 @@ const OpenActionPaidAction: FC<OpenActionPaidActionProps> = ({
     );
 
   return (
-    <div className="p-5">
+    <div className="px-5 py-3">
       {openActions.map((openAction, index) => (
         <div
           className="flex items-center space-x-2"


### PR DESCRIPTION
## What does this PR do?
Reduced vertical padding in amount section on paid actions

## Related issues

Fixes #4267 

## Type of change

- [x] Enhancement (non-breaking small changes to existing functionality)

## Explanation of the changes
