### PR TITLE
chore: update lock icon color in encrypted post

### DIFF
--- a/apps/web/src/components/Publication/EncryptedPublication.tsx
+++ b/apps/web/src/components/Publication/EncryptedPublication.tsx
@@ -1,6 +1,6 @@
 import type { FC } from 'react';
 
-import { LockClosedIcon } from '@heroicons/react/24/outline';
+import { LockClosedIcon } from '@heroicons/react/24/solid';
 import { Card } from '@hey/ui';
 
 interface EncryptedPublicationProps {

--- a/apps/web/src/components/Publication/EncryptedPublication.tsx
+++ b/apps/web/src/components/Publication/EncryptedPublication.tsx
@@ -13,7 +13,7 @@ const EncryptedPublication: FC<EncryptedPublicationProps> = ({
   return (
     <Card className="!bg-gray-100 dark:!bg-gray-800">
       <div className="flex items-center space-x-1 px-4 py-3 text-sm">
-        <LockClosedIcon className="h-4 w-4 text-gray-500" />
+        <LockClosedIcon className="h-4 w-4 text-green-500" />
         <span>{type} has been encrypted</span>
       </div>
     </Card>


### PR DESCRIPTION
## What does this PR do?
Update the lock closed icon to `text-green-500` in encrypted post.

## Related issues

Fixes #4284

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
