### PR TITLE
fix: show poll expired message 

### DIFF
--- a/apps/web/src/components/Publication/Poll/Choices.tsx
+++ b/apps/web/src/components/Publication/Poll/Choices.tsx
@@ -56,7 +56,7 @@ const Choices: FC<ChoicesProps> = ({ poll, refetch }) => {
       Leafwatch.track(PUBLICATION.WIDGET.POLL.VOTE, { poll_id: id });
       toast.success('Your poll has been casted!');
     } catch {
-      toast.error(Errors.SomethingWentWrong);
+      toast.error(Errors.PollExpired);
     } finally {
       setPollSubmitting(false);
     }

--- a/packages/data/errors.ts
+++ b/packages/data/errors.ts
@@ -4,6 +4,7 @@ export enum Errors {
   Limit500 = 'Limit must be less than 500!',
   NoBody = 'No body provided!',
   NotAllowed = 'Not allowed!',
+  PollExpired = 'Poll expired!',
   SignWallet = 'Please sign in your wallet.',
   SomethingWentWrong = 'Something went wrong!'
 }

--- a/packages/data/errors.ts
+++ b/packages/data/errors.ts
@@ -4,7 +4,7 @@ export enum Errors {
   Limit500 = 'Limit must be less than 500!',
   NoBody = 'No body provided!',
   NotAllowed = 'Not allowed!',
-  PollExpired = 'Poll expired!',
+  PollExpired = 'Sorry, this poll has already expired.',
   SignWallet = 'Please sign in your wallet.',
   SomethingWentWrong = 'Something went wrong!'
 }


### PR DESCRIPTION
@bigint 
## What does this PR do?
Shows "Sorry, this poll has already expired" error message when poll duration is expired.

## Related issues

Fixes #4265 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes
Created new key in Errors enum named "PollExpired" which stores "Sorry, this poll has already expired.". Used this new key to show requested error message in Choices component 
