### PR TITLE
fix: spotify link oembed

### DIFF
--- a/apps/api/src/utils/oembed/meta/generateIframe.ts
+++ b/apps/api/src/utils/oembed/meta/generateIframe.ts
@@ -5,6 +5,7 @@ const knownSites = [
   'twitch.tv',
   'kick.com',
   'open.spotify.com',
+  'spotify.link',
   'soundcloud.com',
   'oohlala.xyz'
 ];
@@ -82,6 +83,24 @@ const generateIframe = (
       }
 
       if (spotifyPlaylistUrlRegex.test(url)) {
+        const spotifyUrl = pickedUrl.replace('/playlist', '/embed/playlist');
+        return `<iframe src="${spotifyUrl}" ${spotifySize} height="380" allow="encrypted-media"></iframe>`;
+      }
+
+      return null;
+    }
+    case 'spotify.link': {
+      const spotifySize = `style="max-width: 100%;" width="100%"`;
+      const spotifyEmbedUrl = pickedUrl
+        .replace('spotify:/', 'https://open.spotify.com')
+        .replace(/&context.*/, '')
+        .replace('/?si', '?si');
+      if (spotifyTrackUrlRegex.test(spotifyEmbedUrl)) {
+        const spotifyUrl = spotifyEmbedUrl.replace('/track', '/embed/track');
+        return `<iframe src="${spotifyUrl}" ${spotifySize} height="155" allow="encrypted-media"></iframe>`;
+      }
+
+      if (spotifyPlaylistUrlRegex.test(spotifyEmbedUrl)) {
         const spotifyUrl = pickedUrl.replace('/playlist', '/embed/playlist');
         return `<iframe src="${spotifyUrl}" ${spotifySize} height="380" allow="encrypted-media"></iframe>`;
       }

--- a/apps/api/src/utils/oembed/meta/getEmbedUrl.ts
+++ b/apps/api/src/utils/oembed/meta/getEmbedUrl.ts
@@ -12,6 +12,9 @@ const getEmbedUrl = (document: Document): null | string => {
   const twitter =
     document.querySelector('meta[name="twitter:player"]') ||
     document.querySelector('meta[property="twitter:player"]');
+  const spotify =
+    document.querySelector('meta[name="al:android:url"]') ||
+    document.querySelector('meta[property="al:android:url"]');
 
   if (lens) {
     return lens.getAttribute('content');
@@ -25,6 +28,9 @@ const getEmbedUrl = (document: Document): null | string => {
     return twitter.getAttribute('content');
   }
 
+  if (spotify) {
+    return spotify.getAttribute('content');
+  }
   return null;
 };
 


### PR DESCRIPTION
## What does this PR do?
Extracts embed URL from HTML response for Spotify links and Generate Iframe for the same.

## Related issues

Fixes # (issue)
Fixes #3207
/claim #3207
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes
1. [getEmbedUrl.ts](https://github.com/heyxyz/hey/compare/main...thesloppyguy:hey:fix/spotify.link-oembed?expand=1#diff-7e2ef084b5def3af9b58f06ed6cbef53f9db693015a2abe799dbbf12bd60fa6f) - added conditions to look for embed url for spotify links.
2. [generateIframe.ts](https://github.com/heyxyz/hey/compare/main...thesloppyguy:hey:fix/spotify.link-oembed?expand=1#diff-ec8cd84d25895e858ed95ae6105d507b4f1d799fb6669ee9ca76708d69d6ea3c) - The embed link from step 1 is formatted and the used to create Iframe for spotify links.