### PR TITLE
fix: error message text overflow

### DIFF
--- a/packages/ui/src/ErrorMessage.tsx
+++ b/packages/ui/src/ErrorMessage.tsx
@@ -40,7 +40,7 @@ export const ErrorMessage: FC<ErrorMessageProps> = ({
           </Link>
         </div>
       </div>
-      <div className="text-red-700 dark:text-red-200">{error?.message}</div>
+      <div className="break-words text-red-700 dark:text-red-200">{error?.message}</div>
     </div>
   );
 };


### PR DESCRIPTION
## What does this PR do?
Fixes horizontal text overflow in the error message modal.

<details>
  <summary>Before 👇</summary>
<img src="https://github.com/heyxyz/hey/assets/33344081/2a6f32cc-5d87-4781-9ff2-79023a267e36" />
</details>

<details>
  <summary>After 👇</summary>
  <img src="https://github.com/heyxyz/hey/assets/33344081/a716688a-8261-4577-b065-eb07dba46fbc" />
</details>

## Related issues

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

Adds the tailwindcss class `break-words` to the error message text content to force mid-word breaks if necessary for cases where the text would otherwise horizontally overflow the modal. 
