### PR TITLE
fix: making success toast on Decent OA stay longer

### DIFF
--- a/apps/web/src/hooks/useActOnUnknownOpenAction.tsx
+++ b/apps/web/src/hooks/useActOnUnknownOpenAction.tsx
@@ -64,7 +64,7 @@ const useActOnUnknownOpenAction = ({
 
     onSuccess?.();
     setIsLoading(false);
-    toast.success(successToast || 'Success!');
+    toast.success(successToast || 'Success!', { duration: 5000 });
   };
 
   const { signTypedDataAsync } = useSignTypedData({ mutation: { onError } });


### PR DESCRIPTION
## What does this PR do?
Makes the success toast stay longer

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update