### PR TITLE
feat: add clientProtocol to Frame POST

### DIFF
--- a/apps/api/src/routes/frames/post.ts
+++ b/apps/api/src/routes/frames/post.ts
@@ -79,7 +79,7 @@ export const post: Handler = async (req, res) => {
 
     const { data } = await axios.post(
       postUrl,
-      { trustedData, untrustedData },
+      { clientProtocol: 'lens@1.0.0', trustedData, untrustedData },
       { headers: { 'User-Agent': HEY_USER_AGENT } }
     );
 

--- a/apps/web/src/components/Shared/Oembed/index.tsx
+++ b/apps/web/src/components/Shared/Oembed/index.tsx
@@ -2,7 +2,6 @@ import type { AnyPublication } from '@hey/lens';
 import type { OG } from '@hey/types/misc';
 import type { FC } from 'react';
 
-import isFeatureAvailable from '@helpers/isFeatureAvailable';
 import { HEY_API_URL } from '@hey/data/constants';
 import { ALLOWED_HTML_HOSTS } from '@hey/data/og';
 import getFavicon from '@hey/helpers/getFavicon';
@@ -84,7 +83,7 @@ const Oembed: FC<OembedProps> = ({ onLoad, publication, url }) => {
     return <Player og={og} />;
   }
 
-  if (og.frame && isFeatureAvailable('frames')) {
+  if (og.frame) {
     return <Frame frame={og.frame} publicationId={currentPublication?.id} />;
   }
 

--- a/apps/web/src/components/Shared/Oembed/index.tsx
+++ b/apps/web/src/components/Shared/Oembed/index.tsx
@@ -2,6 +2,7 @@ import type { AnyPublication } from '@hey/lens';
 import type { OG } from '@hey/types/misc';
 import type { FC } from 'react';
 
+import isFeatureAvailable from '@helpers/isFeatureAvailable';
 import { HEY_API_URL } from '@hey/data/constants';
 import { ALLOWED_HTML_HOSTS } from '@hey/data/og';
 import getFavicon from '@hey/helpers/getFavicon';
@@ -83,7 +84,7 @@ const Oembed: FC<OembedProps> = ({ onLoad, publication, url }) => {
     return <Player og={og} />;
   }
 
-  if (og.frame) {
+  if (og.frame && isFeatureAvailable('frames')) {
     return <Frame frame={og.frame} publicationId={currentPublication?.id} />;
   }
 


### PR DESCRIPTION
## What does this PR do?

Frame POST must include `clientProtocol` for authenticated requests to specify protocol to verify Frame signature with.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes
