### PR TITLE
feat: remove condition for frame buttons.length > 0

### DIFF
--- a/apps/api/src/helpers/oembed/meta/getFrame.ts
+++ b/apps/api/src/helpers/oembed/meta/getFrame.ts
@@ -44,7 +44,7 @@ const getFrame = (document: Document, url?: string): Frame | null => {
   }
 
   // Frame must contain valid elements
-  if (!postUrl || !image || buttons.length === 0) {
+  if (!postUrl || !image) {
     return null;
   }
 


### PR DESCRIPTION
## What does this PR do?

Allow Frames with no buttons. This is a common ending state, and is allowed in Open Frames spec and framesjs debugger.

Hey renders these Frames correctly already with this condition removed.

Example: https://stg-powered-by.percs.app/frames/aaa95153-6142-443f-9476-6d442bec9477/1

## Related issues

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes
