### PR TITLE
feat: anonymous frame spec support

### DIFF
--- a/apps/api/src/helpers/middlewares/validateLensAccount.ts
+++ b/apps/api/src/helpers/middlewares/validateLensAccount.ts
@@ -18,9 +18,6 @@ const validateLensAccount = async (
   res: Response,
   next: NextFunction
 ) => {
-  if (req.body.acceptsAnonymous) {
-    return next();
-  }
   const identityToken = req.headers['x-identity-token'] as string;
   if (!identityToken) {
     return catchedError(res, new Error(Errors.Unauthorized), 401);

--- a/apps/api/src/helpers/middlewares/validateLensAccount.ts
+++ b/apps/api/src/helpers/middlewares/validateLensAccount.ts
@@ -18,6 +18,9 @@ const validateLensAccount = async (
   res: Response,
   next: NextFunction
 ) => {
+  if (req.body.acceptsAnonymous) {
+    return next();
+  }
   const identityToken = req.headers['x-identity-token'] as string;
   if (!identityToken) {
     return catchedError(res, new Error(Errors.Unauthorized), 401);

--- a/apps/api/src/helpers/oembed/meta/getFrame.ts
+++ b/apps/api/src/helpers/oembed/meta/getFrame.ts
@@ -49,7 +49,8 @@ const getFrame = (document: Document, url?: string): Frame | null => {
   }
 
   return {
-    authenticated: !acceptsAnonymous,
+    acceptsAnonymous: Boolean(acceptsAnonymous),
+    acceptsLens: Boolean(lensFramesVersion),
     buttons,
     frameUrl,
     image,

--- a/apps/api/src/routes/frames/post.ts
+++ b/apps/api/src/routes/frames/post.ts
@@ -73,7 +73,7 @@ export const post = [
         IS_MAINNET ? 'mainnet' : 'testnet'
       );
 
-      const trustedData = { messageBytes: signature?.signature };
+      const trustedData = { messageBytes: signature?.signature || '' };
       const untrustedData = {
         identityToken,
         unixTimestamp: Math.floor(Date.now() / 1000),

--- a/apps/web/src/components/Shared/Oembed/Frames/index.tsx
+++ b/apps/web/src/components/Shared/Oembed/Frames/index.tsx
@@ -105,6 +105,8 @@ const Frame: FC<FrameProps> = ({ frame, publicationId }) => {
       const { data }: { data: { frame: IFrame } } = await axios.post(
         `${HEY_API_URL}/frames/post`,
         {
+          acceptsAnonymous: frame.acceptsAnonymous,
+          acceptsLens: frame.acceptsLens,
           buttonIndex: index + 1,
           inputText,
           postUrl: buttons[index].target || buttons[index].postUrl || postUrl,

--- a/packages/types/misc.d.ts
+++ b/packages/types/misc.d.ts
@@ -53,7 +53,8 @@ export type FrameTransaction = {
 };
 
 export interface Frame {
-  authenticated: boolean;
+  acceptsAnonymous: boolean;
+  acceptsLens: boolean;
   buttons: {
     action: ButtonType;
     button: string;


### PR DESCRIPTION
## What does this PR do?

Implements final piece of anonymous frame support. Only signs actions if frame explicitly contains `of:accepts:lens`.

Can be tested by using profile with Lens Manager disable and interacting with https://gm-frame-sable.vercel.app. Currently, this frame will return undefined (since data cannot be properly signed -> returns untrustedData incorrectly).

## Related issues

Closes #5066 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes
