### PR TITLE
chore: migrate away from deprecated prosekit api

### DIFF
--- a/apps/web/src/components/Composer/Editor/Editor.tsx
+++ b/apps/web/src/components/Composer/Editor/Editor.tsx
@@ -24,15 +24,15 @@ const Editor: FC = () => {
   const { publicationContent } = usePublicationStore();
   const defaultMarkdownRef = useRef(publicationContent);
 
-  const defaultHTML = useMemo(() => {
+  const defaultContent = useMemo(() => {
     const markdown = defaultMarkdownRef.current;
     return markdown ? htmlFromMarkdown(markdown) : undefined;
   }, []);
 
   const editor = useMemo(() => {
     const extension = defineEditorExtension();
-    return createEditor({ defaultHTML, extension });
-  }, [defaultHTML]);
+    return createEditor({ defaultContent, extension });
+  }, [defaultContent]);
 
   useContentChange(editor);
   usePaste(editor);


### PR DESCRIPTION
## What does this PR do?


There is a tiny API change in the latest version of ProseKit v0.9.13. A new option `defaultContent` is added and it deprecate the previous `defaultHTML` and `defaultDoc`.


## Related issues

~~Fixes # (issue)~~

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes
