### PR TITLE
Adds suno.com embeds

### DIFF
--- a/apps/api/src/helpers/oembed/getMetadata.ts
+++ b/apps/api/src/helpers/oembed/getMetadata.ts
@@ -1,3 +1,4 @@
+import { PREFER_PLAYER_HOSTS } from "@hey/data/og";
 import getFavicon from "@hey/helpers/getFavicon";
 import type { OG } from "@hey/types/misc";
 import axios from "axios";
@@ -22,11 +23,14 @@ const getMetadata = async (url: string): Promise<null | OG> => {
     const { document } = parseHTML(data);
     const image = getImage(document) as string;
 
+    const host = new URL(url).host;
+    const preferPlayer = PREFER_PLAYER_HOSTS.includes(host);
+
     const metadata: OG = {
       description: getDescription(document),
       favicon: getFavicon(url),
       frame: getFrame(document, url),
-      html: generateIframe(getEmbedUrl(document), url),
+      html: generateIframe(getEmbedUrl(document, preferPlayer), url),
       image: getProxyUrl(image),
       lastIndexedAt: new Date().toISOString(),
       nft: getNft(document, url),

--- a/apps/api/src/helpers/oembed/meta/generateIframe.ts
+++ b/apps/api/src/helpers/oembed/meta/generateIframe.ts
@@ -20,6 +20,7 @@ const tapeRegex =
   /^https?:\/\/tape\.xyz\/watch\/[\dA-Za-z-]+(\?si=[\dA-Za-z]+)?$/;
 const twitchRegex = /^https?:\/\/www\.twitch\.tv\/videos\/[\dA-Za-z-]+$/;
 const kickRegex = /^https?:\/\/kick\.com\/[\dA-Za-z-]+$/;
+const sunoRegex = /^https?:\/\/suno\.com\/song\/[\dA-Za-z-]+$/;
 
 const generateIframe = (
   embedUrl: null | string,
@@ -95,6 +96,14 @@ const generateIframe = (
     case "oohlala.xyz": {
       if (oohlalaUrlRegex.test(cleanedUrl)) {
         return `<iframe src="${pickedUrl}" ${universalSize}></iframe>`;
+      }
+
+      return null;
+    }
+    case "suno.com": {
+      if (sunoRegex.test(cleanedUrl)) {
+        const sunoSize = `style="max-width: 760px;" width="100%"`;
+        return `<iframe src="${pickedUrl}" ${sunoSize} height="155"></iframe>`;
       }
 
       return null;

--- a/apps/api/src/helpers/oembed/meta/getEmbedUrl.spec.ts
+++ b/apps/api/src/helpers/oembed/meta/getEmbedUrl.spec.ts
@@ -84,4 +84,21 @@ describe("getEmbedUrl", () => {
 
     expect(result).toBeNull();
   });
+
+  test("should return the content of 'name=twitter:player' if it's present and preferred", () => {
+    const html = `
+      <html>
+        <head>
+          <meta property="og:video:url" content="https://cdn1.suno.ai/c87ff8b6-1912-440c-9745-0bb5ae7b01d0.mp4">
+          <meta name="twitter:player" content="https://suno.com/embed/c87ff8b6-1912-440c-9745-0bb5ae7b01d0">
+        </head>
+      </html>
+    `;
+    const { document } = parseHTML(html);
+    const result = getEmbedUrl(document, true);
+
+    expect(result).toBe(
+      "https://suno.com/embed/c87ff8b6-1912-440c-9745-0bb5ae7b01d0"
+    );
+  });
 });

--- a/apps/api/src/helpers/oembed/meta/getEmbedUrl.ts
+++ b/apps/api/src/helpers/oembed/meta/getEmbedUrl.ts
@@ -1,4 +1,7 @@
-const getEmbedUrl = (document: Document): null | string => {
+const getEmbedUrl = (
+  document: Document,
+  preferPlayer = false
+): null | string => {
   const og =
     document.querySelector('meta[name="og:video:url"]') ||
     document.querySelector('meta[name="og:video:secure_url"]') ||
@@ -8,15 +11,11 @@ const getEmbedUrl = (document: Document): null | string => {
     document.querySelector('meta[name="twitter:player"]') ||
     document.querySelector('meta[property="twitter:player"]');
 
-  if (og) {
-    return og.getAttribute("content");
-  }
-
-  if (twitter) {
+  if (preferPlayer && twitter) {
     return twitter.getAttribute("content");
   }
 
-  return null;
+  return (og || twitter)?.getAttribute("content") ?? null;
 };
 
 export default getEmbedUrl;

--- a/packages/data/og.ts
+++ b/packages/data/og.ts
@@ -6,7 +6,10 @@ export const ALLOWED_HTML_HOSTS = [
   "kick.com",
   "open.spotify.com",
   "soundcloud.com",
-  "oohlala.xyz"
+  "oohlala.xyz",
+  "suno.com"
 ];
 
 export const IGNORED_NFT_HOSTS = ["hey.xyz"];
+
+export const PREFER_PLAYER_HOSTS = ["suno.com"];


### PR DESCRIPTION
Shows Suno embed player when a suno.com song URL is part of a publication content.

**Note:** Suno provides an `og:video:url` as well as a `twitter:player` tag, but the player embed is generally preferred since it's audio. For that reason, I added logic to check a list of "preferred player hosts" when getting the metadata. Right now, only Suno is on the list.

### Highlights
- Adds suno.com to allowed HTML hosts
- Adds a new list of hosts where player embeds are preferred
- Checks whether player embed is preferred when getting OG metadata
- Adds test to `getEmbedUrl` to test for preferred player hosts

### Screenshots

Composer:
![hey-suno-0](https://github.com/user-attachments/assets/1ca0a656-c1c0-44ae-8137-278bcc29c50c)

Feed:
![hey-suno-1](https://github.com/user-attachments/assets/5e324c1b-41fd-4c3f-a96e-baa770bbd6d8)
