### PR TITLE
Don't compress images more while uploading

### DIFF
--- a/apps/web/src/helpers/profilePictureUtils.ts
+++ b/apps/web/src/helpers/profilePictureUtils.ts
@@ -32,8 +32,8 @@ const uploadCroppedImage = async (
   });
   const cleanedFile = await imageCompression(file, {
     exifOrientation: 1,
-    maxSizeMB: 2,
-    maxWidthOrHeight: 4096,
+    maxSizeMB: 3,
+    maxWidthOrHeight: 2000,
     useWebWorker: true
   });
   const attachment = await uploadFileToIPFS(cleanedFile);

--- a/apps/web/src/hooks/useUploadAttachments.tsx
+++ b/apps/web/src/hooks/useUploadAttachments.tsx
@@ -61,8 +61,8 @@ const useUploadAttachments = () => {
           if (file.type.includes("image") && !file.type.includes("gif")) {
             return await imageCompression(file, {
               exifOrientation: 1,
-              maxSizeMB: 2,
-              maxWidthOrHeight: 4096,
+              maxSizeMB: 3,
+              maxWidthOrHeight: 5000,
               useWebWorker: true
             });
           }


### PR DESCRIPTION
This pull request includes changes to the image compression settings in two different files to improve the handling of image uploads. The adjustments involve increasing the maximum file size and modifying the maximum width or height for compressed images.

Changes to image compression settings:

* [`apps/web/src/helpers/profilePictureUtils.ts`](diffhunk://#diff-f5b6e8f1b6d0c04f07c63494c14145e6eb17b8d6485c0f3dce8092796d67b073L35-R36): Increased `maxSizeMB` from 2 to 3 and decreased `maxWidthOrHeight` from 4096 to 2000 in the `uploadCroppedImage` function.
* [`apps/web/src/hooks/useUploadAttachments.tsx`](diffhunk://#diff-fe28f137d985355899f12321440395c6483572f779390caf8de7b188806a2cc7L64-R65): Increased `maxSizeMB` from 2 to 3 and increased `maxWidthOrHeight` from 4096 to 5000 in the `useUploadAttachments` hook.