### PR TITLE
Fix search input reset on enter

### DIFF
--- a/apps/web/src/components/Shared/Navbar/Search/index.tsx
+++ b/apps/web/src/components/Shared/Navbar/Search/index.tsx
@@ -56,6 +56,7 @@ const Search: FC<SearchProps> = ({ placeholder = "Search…" }) => {
     } else {
       push(`/search?q=${encodeURIComponent(searchText)}&type=profiles`);
     }
+    reset();
   };
 
   useEffect(() => {

--- a/apps/web/src/components/Shared/Navbar/Search/index.tsx
+++ b/apps/web/src/components/Shared/Navbar/Search/index.tsx
@@ -34,7 +34,6 @@ const Search: FC<SearchProps> = ({ placeholder = "Search…" }) => {
   const reset = () => {
     setShowDropdown(false);
     setProfiles([]);
-    setSearchText("");
   };
 
   const dropdownRef = useClickAway(() => {
@@ -57,7 +56,6 @@ const Search: FC<SearchProps> = ({ placeholder = "Search…" }) => {
     } else {
       push(`/search?q=${encodeURIComponent(searchText)}&type=profiles`);
     }
-    reset();
   };
 
   useEffect(() => {


### PR DESCRIPTION
Fixes #5413

Remove the call to `reset` in the `handleKeyDown` function and update the `reset` function to no longer clear the search input.

* Remove the line `setSearchText("");` from the `reset` function.
* Remove the call to `reset` in the `handleKeyDown` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/heyxyz/hey/issues/5413?shareId=158d40cb-002f-480f-a5d5-0a048703e612).