### PR TITLE
Fix truncation of profile on big handles and names

### DIFF
--- a/apps/web/src/components/Publication/ClubHandle.tsx
+++ b/apps/web/src/components/Publication/ClubHandle.tsx
@@ -15,8 +15,8 @@ const ClubHandle: FC<ClubHandleProps> = ({ tags }) => {
   }
 
   return (
-    <span className="ld-text-gray-500 linkify truncate">
-      <span className="mx-1">·</span>
+    <span className="ld-text-gray-500 linkify">
+      <span className="mr-1">·</span>
       <ClubPreview handle={club}>
         <Link className="text-xs hover:underline" href={`/c/${club}`}>
           /{club}

--- a/apps/web/src/components/Publication/PublicationProfile.tsx
+++ b/apps/web/src/components/Publication/PublicationProfile.tsx
@@ -28,7 +28,7 @@ const PublicationProfile: FC<FeedUserProfileProps> = ({
 }) => {
   const WrappedLink = ({ children }: { children: ReactNode }) => (
     <Link
-      className="truncate outline-none hover:underline focus:underline"
+      className="outline-none hover:underline focus:underline"
       href={getProfile(profile).link}
     >
       <ProfilePreview
@@ -42,21 +42,18 @@ const PublicationProfile: FC<FeedUserProfileProps> = ({
   );
 
   return (
-    <div className="flex max-w-sm flex-wrap items-center">
+    <div className="flex flex-wrap items-center gap-x-1">
       <WrappedLink>
         <span className="font-semibold">{getProfile(profile).displayName}</span>
       </WrappedLink>
       <WrappedLink>
-        <Slug
-          className="ml-1 truncate text-sm"
-          slug={getProfile(profile).slugWithPrefix}
-        />
+        <Slug className="text-sm" slug={getProfile(profile).slugWithPrefix} />
       </WrappedLink>
-      <Verified id={profile.id} iconClassName="ml-1 size-4" />
-      <Misuse id={profile.id} iconClassName="ml-1 size-4" />
+      <Verified id={profile.id} iconClassName="size-4" />
+      <Misuse id={profile.id} iconClassName="size-4" />
       {timestamp ? (
-        <span className="ld-text-gray-500 truncate">
-          <span className="mx-1">·</span>
+        <span className="ld-text-gray-500">
+          <span className="mr-1">·</span>
           <Link
             className="text-xs hover:underline"
             href={`/posts/${publicationId}`}

--- a/apps/web/src/components/Publication/Source.tsx
+++ b/apps/web/src/components/Publication/Source.tsx
@@ -17,7 +17,7 @@ const Source: FC<SourceProps> = ({ publishedOn }) => {
 
   return (
     <span className="ld-text-gray-500 flex items-center">
-      <span className="mx-1">·</span>
+      <span className="mr-1">·</span>
       <img
         alt="Logo"
         className="mt-0.5 h-3.5 rounded-sm"


### PR DESCRIPTION
This pull request includes several changes to improve the layout and styling of components in the `apps/web/src/components/Publication` directory. The changes primarily focus on removing unnecessary truncation and adjusting spacing for better visual consistency.

Styling improvements:

* [`apps/web/src/components/Publication/ClubHandle.tsx`](diffhunk://#diff-5403181ff579f9dc95e8b14d059088a0f549c27231c3410c22e527e2e5ed0b26L18-R19): Removed the `truncate` class from the `span` element and adjusted the margin class from `mx-1` to `mr-1` for better spacing.
* [`apps/web/src/components/Publication/PublicationProfile.tsx`](diffhunk://#diff-7df9e0acc22c3e1ef5cd6624b7063c11ee5df3e20821d97927aea6005471cea6L31-R31): Removed the `truncate` class from the `WrappedLink` component and adjusted the layout by removing unnecessary truncation and updating margin classes. [[1]](diffhunk://#diff-7df9e0acc22c3e1ef5cd6624b7063c11ee5df3e20821d97927aea6005471cea6L31-R31) [[2]](diffhunk://#diff-7df9e0acc22c3e1ef5cd6624b7063c11ee5df3e20821d97927aea6005471cea6L45-R56)
* [`apps/web/src/components/Publication/Source.tsx`](diffhunk://#diff-21ed970ec3db2f9560054fd7fd94974920a6c96ac3a69db45db38e5a5b256c24L20-R20): Adjusted the margin class from `mx-1` to `mr-1` for better spacing.