### PR TITLE
Add CSRF handling on API endpoints

### DIFF
--- a/apps/api/src/helpers/middlewares/csrf.ts
+++ b/apps/api/src/helpers/middlewares/csrf.ts
@@ -1,0 +1,5 @@
+import helmet from "helmet";
+
+const csrfProtection = helmet.csrf();
+
+export default csrfProtection;

--- a/apps/api/src/routes/email/update.ts
+++ b/apps/api/src/routes/email/update.ts
@@ -9,6 +9,7 @@ import catchedError from "src/helpers/catchedError";
 import sendEmail from "src/helpers/email/sendEmail";
 import { rateLimiter } from "src/helpers/middlewares/rateLimiter";
 import validateLensAccount from "src/helpers/middlewares/validateLensAccount";
+import csrfProtection from "src/helpers/middlewares/csrf";
 import { invalidBody, noBody } from "src/helpers/responses";
 import { v4 as uuid } from "uuid";
 import { boolean, object, string } from "zod";
@@ -27,6 +28,7 @@ const validationSchema = object({
 export const post = [
   rateLimiter({ requests: 50, within: 60 }),
   validateLensAccount,
+  csrfProtection,
   async (req: Request, res: Response) => {
     const { body } = req;
 

--- a/apps/api/src/routes/email/verify.ts
+++ b/apps/api/src/routes/email/verify.ts
@@ -4,25 +4,29 @@ import logger from "@hey/helpers/logger";
 import type { Request, Response } from "express";
 import catchedError from "src/helpers/catchedError";
 import { noBody } from "src/helpers/responses";
+import csrfProtection from "src/helpers/middlewares/csrf";
 
-export const get = async (req: Request, res: Response) => {
-  const { token } = req.query;
+export const get = [
+  csrfProtection,
+  async (req: Request, res: Response) => {
+    const { token } = req.query;
 
-  if (!token) {
-    return noBody(res);
+    if (!token) {
+      return noBody(res);
+    }
+
+    try {
+      const updatedEmail = await prisma.email.update({
+        data: { tokenExpiresAt: null, verificationToken: null, verified: true },
+        where: { verificationToken: token as string }
+      });
+
+      await delRedis(`preference:${updatedEmail.id}`);
+      logger.info(`Email verified for ${updatedEmail.email}`);
+
+      return res.redirect("https://hey.xyz");
+    } catch (error) {
+      return catchedError(res, error);
+    }
   }
-
-  try {
-    const updatedEmail = await prisma.email.update({
-      data: { tokenExpiresAt: null, verificationToken: null, verified: true },
-      where: { verificationToken: token as string }
-    });
-
-    await delRedis(`preference:${updatedEmail.id}`);
-    logger.info(`Email verified for ${updatedEmail.email}`);
-
-    return res.redirect("https://hey.xyz");
-  } catch (error) {
-    return catchedError(res, error);
-  }
-};
+];

--- a/apps/api/src/routes/webhooks/signup.ts
+++ b/apps/api/src/routes/webhooks/signup.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from "express";
 import catchedError from "src/helpers/catchedError";
 import validateSecret from "src/helpers/middlewares/validateSecret";
+import csrfProtection from "src/helpers/middlewares/csrf";
 import { invalidBody, noBody } from "src/helpers/responses";
 import sendSignupNotificationToSlack from "src/helpers/webhooks/signup/sendSignupNotificationToSlack";
 import { any, object } from "zod";
@@ -15,6 +16,7 @@ const validationSchema = object({
 
 export const post = [
   validateSecret,
+  csrfProtection,
   (req: Request, res: Response) => {
     const { body } = req;
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -3,6 +3,7 @@ import cors from "cors";
 import dotenv from "dotenv";
 import express from "express";
 import { router } from "express-file-routing";
+import helmet from "helmet";
 
 // Load environment variables
 dotenv.config({ override: true });
@@ -14,6 +15,8 @@ app.disable("x-powered-by");
 // Middleware configuration
 app.use(cors());
 app.use(express.json({ limit: "1mb" }));
+app.use(helmet()); // P06b1
+app.use(helmet.csrf()); // Pcd34
 
 //  Increase request timeout
 app.use((req, _, next) => {

--- a/apps/web/src/helpers/getAuthApiHeaders.ts
+++ b/apps/web/src/helpers/getAuthApiHeaders.ts
@@ -8,7 +8,8 @@ export const getAuthApiHeadersWithAccessToken = () => {
   const tokens = hydrateAuthTokens();
   return {
     "X-Access-Token": tokens.accessToken,
-    "X-Identity-Token": tokens.identityToken
+    "X-Identity-Token": tokens.identityToken,
+    "X-CSRF-Token": localStorage.getItem("csrfToken")
   };
 };
 
@@ -18,6 +19,7 @@ export const getAuthApiHeadersWithAccessToken = () => {
  */
 export const getAuthApiHeaders = () => {
   return {
-    "X-Identity-Token": hydrateAuthTokens()?.identityToken
+    "X-Identity-Token": hydrateAuthTokens()?.identityToken,
+    "X-CSRF-Token": localStorage.getItem("csrfToken")
   };
 };

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -3,8 +3,23 @@ import { heyFont } from "@helpers/fonts";
 import { AxiomWebVitals } from "next-axiom";
 import type { AppProps } from "next/app";
 import "../styles.css";
+import { useEffect } from "react";
 
 const App = ({ Component, pageProps }: AppProps) => {
+  useEffect(() => {
+    const fetchCsrfToken = async () => {
+      try {
+        const response = await fetch("/api/csrf-token");
+        const data = await response.json();
+        localStorage.setItem("csrfToken", data.csrfToken);
+      } catch (error) {
+        console.error("Failed to fetch CSRF token:", error);
+      }
+    };
+
+    fetchCsrfToken();
+  }, []);
+
   return (
     <Providers>
       <style global jsx>{`


### PR DESCRIPTION
Related to #5356

Add CSRF handling to API endpoints and web application.

* **API Changes:**
  - Import and use `helmet` middleware for CSRF protection in `apps/api/src/server.ts`.
  - Create a new middleware file `apps/api/src/helpers/middlewares/csrf.ts` for CSRF protection.
  - Import and use the CSRF middleware in `apps/api/src/routes/email/update.ts`, `apps/api/src/routes/email/verify.ts`, and `apps/api/src/routes/webhooks/signup.ts`.

* **Web Application Changes:**
  - Modify `apps/web/src/helpers/getAuthApiHeaders.ts` to include the CSRF token in the headers.
  - Obtain the CSRF token from the server and store it securely in `apps/web/src/pages/_app.tsx`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/heyxyz/hey/pull/5446?shareId=eb76c0c8-d793-4540-bb90-eb8af61156f6).