### PR TITLE
Fix typo in regex comment

### DIFF
--- a/packages/data/regex.ts
+++ b/packages/data/regex.ts
@@ -3,7 +3,7 @@ import regexLookbehindAvailable from "./utils/regexLookbehindAvailable";
 const RESTRICTED_SYMBOLS = "☑️✓✔✅";
 
 // We only want to match mention when the `@` character is at the start of the
-// line or right after a whilespace.
+// line or right after a whitespace.
 const MATCH_BEHIND = regexLookbehindAvailable ? "(?<=^|\\s)" : "";
 
 const MENTION_NAMESPACE = "\\w+\\/";


### PR DESCRIPTION
## Summary
- correct `whilespace` typo in packages/data/regex.ts comment

## Testing
- `pnpm test`
- `pnpm biome:check`


------
https://chatgpt.com/codex/tasks/task_e_6841347dc43c8330abfffb16064cb4b3