### PR TITLE
Refactor getWalletDetails

### DIFF
--- a/apps/web/src/helpers/getWalletDetails.ts
+++ b/apps/web/src/helpers/getWalletDetails.ts
@@ -1,27 +1,29 @@
 import { STATIC_IMAGES_URL } from "@hey/data/constants";
 
-interface WalletDetails {
+export interface WalletDetails {
   logo: string;
   name: string;
 }
 
-const getWalletDetails = (id: string): WalletDetails => {
-  const walletDetails: Record<string, WalletDetails> = {
-    familyAccountsProvider: {
-      logo: `${STATIC_IMAGES_URL}/wallets/family.png`,
-      name: "Login with Family"
-    },
-    walletConnect: {
-      logo: `${STATIC_IMAGES_URL}/wallets/walletconnect.svg`,
-      name: "Wallet Connect"
-    },
-    injected: {
-      logo: `${STATIC_IMAGES_URL}/wallets/wallet.svg`,
-      name: "Browser Wallet"
-    }
-  };
+const WALLETS = {
+  familyAccountsProvider: {
+    logo: `${STATIC_IMAGES_URL}/wallets/family.png`,
+    name: "Login with Family"
+  },
+  walletConnect: {
+    logo: `${STATIC_IMAGES_URL}/wallets/walletconnect.svg`,
+    name: "Wallet Connect"
+  },
+  injected: {
+    logo: `${STATIC_IMAGES_URL}/wallets/wallet.svg`,
+    name: "Browser Wallet"
+  }
+} as const;
 
-  return walletDetails[id];
+export type WalletId = keyof typeof WALLETS;
+
+const getWalletDetails = (id: WalletId): WalletDetails => {
+  return WALLETS[id];
 };
 
 export default getWalletDetails;


### PR DESCRIPTION
## Summary
- refactor `getWalletDetails` helper to reuse a constant map and type for known wallet IDs

## Testing
- `pnpm biome:check`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68413dd0d064833096f0c88e07239dd8