### PR TITLE
Refactor sanitizeDStorageUrl

### DIFF
--- a/packages/helpers/sanitizeDStorageUrl.ts
+++ b/packages/helpers/sanitizeDStorageUrl.ts
@@ -1,20 +1,22 @@
 import { IPFS_GATEWAY, STORAGE_NODE_URL } from "@hey/data/constants";
 
-const sanitizeDStorageUrl = (hash?: string): string => {
-  if (!hash) {
+const sanitizeDStorageUrl = (url?: string): string => {
+  if (!url) {
     return "";
   }
 
   const ipfsGateway = `${IPFS_GATEWAY}/`;
 
-  let link = hash.replace(/^Qm[1-9A-Za-z]{44}/gm, `${IPFS_GATEWAY}/${hash}`);
-  link = link.replace("https://ipfs.io/ipfs/", ipfsGateway);
-  link = link.replace("ipfs://ipfs/", ipfsGateway);
-  link = link.replace("ipfs://", ipfsGateway);
-  link = link.replace("lens://", `${STORAGE_NODE_URL}/`);
-  link = link.replace("ar://", "https://gateway.arweave.net/");
+  if (/^Qm[1-9A-Za-z]{44}/.test(url)) {
+    return `${ipfsGateway}${url}`;
+  }
 
-  return link;
+  return url
+    .replace("https://ipfs.io/ipfs/", ipfsGateway)
+    .replace("ipfs://ipfs/", ipfsGateway)
+    .replace("ipfs://", ipfsGateway)
+    .replace("lens://", `${STORAGE_NODE_URL}/`)
+    .replace("ar://", "https://gateway.arweave.net/");
 };
 
 export default sanitizeDStorageUrl;


### PR DESCRIPTION
## Summary
- streamline sanitizeDStorageUrl to use early returns and chaining

## Testing
- `pnpm biome:check`
- `pnpm --recursive --parallel run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6842fbc736f883309361f3da8b199ce7