### PR TITLE
Add middleware tests

### DIFF
--- a/apps/api/src/context/authContext.test.ts
+++ b/apps/api/src/context/authContext.test.ts
@@ -1,0 +1,44 @@
+import type { Context, Next } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import authContext from "./authContext";
+
+const createToken = (payload: object) => {
+  const encoded = Buffer.from(JSON.stringify(payload)).toString("base64");
+  return `a.${encoded}.b`;
+};
+
+describe("authContext", () => {
+  it("stores account and token when valid", async () => {
+    const token = createToken({
+      sub: "",
+      exp: 0,
+      sid: "",
+      act: { sub: "user" }
+    });
+    const headers = new Headers({ "X-Access-Token": token });
+    const ctx = {
+      req: { raw: { headers } },
+      set: vi.fn()
+    } as unknown as Context;
+    const next: Next = vi.fn();
+
+    await authContext(ctx, next);
+
+    expect(ctx.set).toHaveBeenCalledWith("account", "user");
+    expect(ctx.set).toHaveBeenCalledWith("token", token);
+  });
+
+  it("clears values when token invalid", async () => {
+    const headers = new Headers({ "X-Access-Token": "invalid" });
+    const ctx = {
+      req: { raw: { headers } },
+      set: vi.fn()
+    } as unknown as Context;
+    const next: Next = vi.fn();
+
+    await authContext(ctx, next);
+
+    expect(ctx.set).toHaveBeenCalledWith("account", null);
+    expect(ctx.set).toHaveBeenCalledWith("token", null);
+  });
+});

--- a/apps/api/src/middlewares/__tests__/authMiddleware.test.ts
+++ b/apps/api/src/middlewares/__tests__/authMiddleware.test.ts
@@ -1,0 +1,34 @@
+import type { Context, Next } from "hono";
+import { jwtVerify } from "jose";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import authMiddleware from "../authMiddleware";
+
+vi.mock("jose", () => ({
+  createRemoteJWKSet: vi.fn(() => "jwk"),
+  jwtVerify: vi.fn()
+}));
+
+const next: Next = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("authMiddleware", () => {
+  it("calls next on valid token", async () => {
+    (jwtVerify as unknown as any).mockResolvedValueOnce({});
+    const ctx = { get: vi.fn(() => "token") } as unknown as Context;
+    await authMiddleware(ctx, next);
+    expect(jwtVerify).toHaveBeenCalledWith("token", "jwk");
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("returns 401 on invalid token", async () => {
+    (jwtVerify as unknown as any).mockRejectedValueOnce(new Error("bad"));
+    const body = vi.fn();
+    const ctx = { get: vi.fn(() => "token"), body } as unknown as Context;
+    await authMiddleware(ctx, next);
+    expect(body).toHaveBeenCalledWith("Unauthorized", 401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/middlewares/__tests__/cors.test.ts
+++ b/apps/api/src/middlewares/__tests__/cors.test.ts
@@ -1,0 +1,22 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+const corsMock = vi.fn((opts) => opts);
+vi.mock("hono/cors", () => ({ cors: corsMock }));
+
+let cors: any;
+
+beforeAll(async () => {
+  ({ default: cors } = await import("../cors"));
+});
+
+describe("cors middleware", () => {
+  it("sets allowed origins", () => {
+    expect(cors.origin).toEqual([
+      "https://hey.xyz",
+      "https://testnet.hey.xyz",
+      "https://staging.hey.xyz",
+      "http://localhost:4783",
+      "https://developer.lens.xyz"
+    ]);
+  });
+});

--- a/apps/api/src/middlewares/__tests__/infoLogger.test.ts
+++ b/apps/api/src/middlewares/__tests__/infoLogger.test.ts
@@ -1,0 +1,30 @@
+import type { Context, Next } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import infoLogger from "../infoLogger";
+
+describe("infoLogger", () => {
+  it("logs formatted message", async () => {
+    const now = vi.spyOn(performance, "now");
+    now.mockReturnValueOnce(0).mockReturnValueOnce(50);
+    const mem = vi.spyOn(process, "memoryUsage");
+    mem
+      .mockReturnValueOnce({ heapUsed: 1000 } as any)
+      .mockReturnValueOnce({ heapUsed: 2000 } as any);
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+    const next: Next = vi.fn();
+    const ctx = {
+      req: { method: "GET", path: "/a", header: vi.fn(() => "GPTBot") }
+    } as unknown as Context;
+
+    await infoLogger(ctx, next);
+
+    expect(info).toHaveBeenCalledWith(
+      "[GET /a] \u279c [GPTBot] \u279c 50.00ms, 0.00mb"
+    );
+    expect(next).toHaveBeenCalled();
+
+    now.mockRestore();
+    mem.mockRestore();
+    info.mockRestore();
+  });
+});

--- a/apps/api/src/middlewares/__tests__/rateLimiter.test.ts
+++ b/apps/api/src/middlewares/__tests__/rateLimiter.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import sha256 from "../../utils/sha256";
+
+vi.mock("hono-rate-limiter", () => ({
+  rateLimiter: vi.fn((opts) => opts)
+}));
+
+import rateLimiter from "../rateLimiter";
+
+const headers = new Headers({ "x-forwarded-for": "1.1.1.1" });
+
+describe("rateLimiter", () => {
+  it("generates key based on url and ip", () => {
+    const middleware = rateLimiter({ requests: 1 }) as any;
+    const ctx = { req: { url: "/test", raw: { headers } } } as any;
+    const key = middleware.keyGenerator(ctx);
+    const expected = `rate-limit:${sha256("/test").slice(0, 25)}:${sha256("1.1.1.1").slice(0, 25)}`;
+    expect(key).toBe(expected);
+  });
+});

--- a/apps/api/src/middlewares/__tests__/secretMiddleware.test.ts
+++ b/apps/api/src/middlewares/__tests__/secretMiddleware.test.ts
@@ -1,0 +1,32 @@
+import type { Context, Next } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import secretMiddleware from "../secretMiddleware";
+
+const next: Next = vi.fn();
+
+describe("secretMiddleware", () => {
+  it("returns 401 when secret invalid", async () => {
+    process.env.SHARED_SECRET = "top";
+    const body = vi.fn();
+    const ctx = {
+      req: { query: vi.fn(() => "wrong") },
+      body
+    } as unknown as Context;
+
+    await secretMiddleware(ctx, next);
+
+    expect(body).toHaveBeenCalledWith("Unauthorized", 401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls next when secret valid", async () => {
+    process.env.SHARED_SECRET = "secret";
+    const ctx = {
+      req: { query: vi.fn(() => "secret") }
+    } as unknown as Context;
+
+    await secretMiddleware(ctx, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add test coverage for API middlewares and context

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build` *(fails: vite build error)*

------
https://chatgpt.com/codex/tasks/task_e_68444bb7f02c8330883ff620a46aa224