### PR TITLE
Refactor OG routes with helper

### DIFF
--- a/apps/api/src/routes/og/getAccount.ts
+++ b/apps/api/src/routes/og/getAccount.ts
@@ -3,99 +3,80 @@ import escapeHtml from "@hey/helpers/escapeHtml";
 import { default as getAccountData } from "@hey/helpers/getAccount";
 import getAvatar from "@hey/helpers/getAvatar";
 import { AccountDocument } from "@hey/indexer";
-import apolloClient from "@hey/indexer/apollo/client";
 import type { Context } from "hono";
 import { html, raw } from "hono/html";
-import defaultMetadata from "src/utils/defaultMetadata";
-import { getRedis, setRedis } from "src/utils/redis";
+import generateOg from "./ogUtils";
 
 const getAccount = async (ctx: Context) => {
-  try {
-    const { username } = ctx.req.param();
+  const { username } = ctx.req.param();
+  const cacheKey = `og:account:${username}`;
 
-    const cacheKey = `og:account:${username}`;
-    const cachedAccount = await getRedis(cacheKey);
+  return generateOg({
+    ctx,
+    cacheKey,
+    query: AccountDocument,
+    variables: { request: { username: { localName: username } } },
+    extractData: (data) => data.account,
+    buildJsonLd: (account) => {
+      const { name, usernameWithPrefix } = getAccountData(account);
+      const title = `${name} (${usernameWithPrefix}) on Hey`;
+      const description = (account?.metadata?.bio || title).slice(0, 155);
 
-    if (cachedAccount) {
-      return ctx.html(cachedAccount, 200);
+      return {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "@id": `https://hey.xyz/u/${username}`,
+        name,
+        alternateName: username,
+        description,
+        image: getAvatar(account, TRANSFORMS.AVATAR_BIG),
+        url: `https://hey.xyz/u/${username}`,
+        memberOf: { "@type": "Organization", name: "Hey.xyz" }
+      };
+    },
+    buildHtml: (account, escapedJsonLd) => {
+      const { name, link, usernameWithPrefix } = getAccountData(account);
+      const title = `${name} (${usernameWithPrefix}) on Hey`;
+      const description = (account?.metadata?.bio || title).slice(0, 155);
+      const avatar = getAvatar(account, TRANSFORMS.AVATAR_BIG);
+
+      const escTitle = escapeHtml(title);
+      const escDescription = escapeHtml(description);
+      const escName = escapeHtml(name);
+      const escUsernameWithPrefix = escapeHtml(usernameWithPrefix);
+
+      return html`
+        <html>
+          <head>
+            <meta charSet="utf-8" />
+            <meta name="viewport" content="width=device-width" />
+            <title>${escTitle}</title>
+            <meta name="description" content="${escDescription}" />
+            <meta property="og:title" content="${escTitle}" />
+            <meta property="og:description" content="${escDescription}" />
+            <meta property="og:type" content="profile" />
+            <meta property="og:site_name" content="Hey" />
+            <meta property="og:url" content="https://hey.xyz${link}" />
+            <meta property="og:image" content="${avatar}" />
+            <meta property="og:logo" content="${STATIC_IMAGES_URL}/app-icon/0.png" />
+            <meta name="twitter:card" content="summary" />
+            <meta name="twitter:title" content="${escTitle}" />
+            <meta name="twitter:description" content="${escDescription}" />
+            <meta property="twitter:image" content="${avatar}" />
+            <meta name="twitter:site" content="@heydotxyz" />
+            <link rel="canonical" href="https://hey.xyz${link}" />
+          </head>
+          <body>
+            <script type="application/ld+json">${raw(escapedJsonLd)}</script>
+            <img src="${avatar}" alt="${escName}" height="100" width="100" />
+            <h1>${escName || username}</h1>
+            <h2>${escUsernameWithPrefix}</h2>
+            <h3>${escDescription}</h3>
+          </body>
+        </html>
+      `;
     }
-
-    const { data } = await apolloClient.query({
-      query: AccountDocument,
-      variables: { request: { username: { localName: username } } },
-      fetchPolicy: "no-cache"
-    });
-
-    if (!data.account) {
-      return ctx.html(defaultMetadata, 404);
-    }
-
-    const account = data.account;
-    const { name, link, usernameWithPrefix } = getAccountData(account);
-    const title = `${name} (${usernameWithPrefix}) on Hey`;
-    const description = (account?.metadata?.bio || title).slice(0, 155);
-    const avatar = getAvatar(account, TRANSFORMS.AVATAR_BIG);
-
-    const escTitle = escapeHtml(title);
-    const escDescription = escapeHtml(description);
-    const escName = escapeHtml(name);
-    const escUsernameWithPrefix = escapeHtml(usernameWithPrefix);
-
-    const jsonLd = {
-      "@context": "https://schema.org",
-      "@type": "Person",
-      "@id": `https://hey.xyz/u/${username}`,
-      name,
-      alternateName: username,
-      description,
-      image: avatar,
-      url: `https://hey.xyz/u/${username}`,
-      memberOf: { "@type": "Organization", name: "Hey.xyz" }
-    };
-
-    const escapedJsonLd = JSON.stringify(jsonLd)
-      .replace(/</g, "\\u003c")
-      .replace(/>/g, "\\u003e")
-      .replace(/&/g, "\\u0026");
-
-    const ogHtml = html`
-      <html>
-        <head>
-          <meta charSet="utf-8" />
-          <meta name="viewport" content="width=device-width" />
-          <title>${escTitle}</title>
-          <meta name="description" content="${escDescription}" />
-          <meta property="og:title" content="${escTitle}" />
-          <meta property="og:description" content="${escDescription}" />
-          <meta property="og:type" content="profile" />
-          <meta property="og:site_name" content="Hey" />
-          <meta property="og:url" content="https://hey.xyz${link}" />
-          <meta property="og:image" content="${avatar}" />
-          <meta property="og:logo" content="${STATIC_IMAGES_URL}/app-icon/0.png" />
-          <meta name="twitter:card" content="summary" />
-          <meta name="twitter:title" content="${escTitle}" />
-          <meta name="twitter:description" content="${escDescription}" />
-          <meta property="twitter:image" content="${avatar}" />
-          <meta name="twitter:site" content="@heydotxyz" />
-          <link rel="canonical" href="https://hey.xyz${link}" />
-        </head>
-        <body>
-          <script type="application/ld+json">${raw(escapedJsonLd)}</script>
-          <img src="${avatar}" alt="${escName}" height="100" width="100" />
-          <h1>${escName || username}</h1>
-          <h2>${escUsernameWithPrefix}</h2>
-          <h3>${escDescription}</h3>
-        </body>
-      </html>
-    `;
-
-    const cleanHtml = ogHtml.toString().replace(/\n\s+/g, "").trim();
-    await setRedis(cacheKey, cleanHtml);
-
-    return ctx.html(ogHtml, 200);
-  } catch {
-    return ctx.html(defaultMetadata, 500);
-  }
+  });
 };
 
 export default getAccount;

--- a/apps/api/src/routes/og/getGroup.ts
+++ b/apps/api/src/routes/og/getGroup.ts
@@ -2,97 +2,78 @@ import { STATIC_IMAGES_URL, TRANSFORMS } from "@hey/data/constants";
 import escapeHtml from "@hey/helpers/escapeHtml";
 import getAvatar from "@hey/helpers/getAvatar";
 import { GroupDocument, type GroupFragment } from "@hey/indexer";
-import apolloClient from "@hey/indexer/apollo/client";
 import type { Context } from "hono";
 import { html, raw } from "hono/html";
-import defaultMetadata from "src/utils/defaultMetadata";
-import { getRedis, setRedis } from "src/utils/redis";
+import generateOg from "./ogUtils";
 
 const getGroup = async (ctx: Context) => {
-  try {
-    const { address } = ctx.req.param();
+  const { address } = ctx.req.param();
+  const cacheKey = `og:group:${address}`;
 
-    const cacheKey = `og:group:${address}`;
-    const cachedGroup = await getRedis(cacheKey);
+  return generateOg({
+    ctx,
+    cacheKey,
+    query: GroupDocument,
+    variables: { request: { group: address } },
+    extractData: (data) => data.group as GroupFragment | null,
+    buildJsonLd: (group: GroupFragment) => {
+      const name = group.metadata?.name || "Group";
+      const title = `${name} on Hey`;
+      const description = (group?.metadata?.description || title).slice(0, 155);
 
-    if (cachedGroup) {
-      return ctx.html(cachedGroup, 200);
+      return {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "@id": `https://hey.xyz/g/${address}`,
+        name,
+        alternateName: address,
+        description,
+        image: getAvatar(group, TRANSFORMS.AVATAR_BIG),
+        url: `https://hey.xyz/g/${address}`,
+        memberOf: { "@type": "Organization", name: "Hey.xyz" }
+      };
+    },
+    buildHtml: (group: GroupFragment, escapedJsonLd) => {
+      const name = group.metadata?.name || "Group";
+      const title = `${name} on Hey`;
+      const description = (group?.metadata?.description || title).slice(0, 155);
+      const avatar = getAvatar(group, TRANSFORMS.AVATAR_BIG);
+
+      const escTitle = escapeHtml(title);
+      const escDescription = escapeHtml(description);
+      const escName = escapeHtml(name);
+
+      return html`
+        <html>
+          <head>
+            <meta charSet="utf-8" />
+            <meta name="viewport" content="width=device-width" />
+            <title>${escTitle}</title>
+            <meta name="description" content="${escDescription}" />
+            <meta property="og:title" content="${escTitle}" />
+            <meta property="og:description" content="${escDescription}" />
+            <meta property="og:type" content="profile" />
+            <meta property="og:site_name" content="Hey" />
+            <meta property="og:url" content="https://hey.xyz/g/${group.address}" />
+            <meta property="og:image" content="${avatar}" />
+            <meta property="og:logo" content="${STATIC_IMAGES_URL}/app-icon/0.png" />
+            <meta name="twitter:card" content="summary" />
+            <meta name="twitter:title" content="${escTitle}" />
+            <meta name="twitter:description" content="${escDescription}" />
+            <meta property="twitter:image" content="${avatar}" />
+            <meta name="twitter:site" content="@heydotxyz" />
+            <link rel="canonical" href="https://hey.xyz/g/${group.address}" />
+          </head>
+          <body>
+            <script type="application/ld+json">${raw(escapedJsonLd)}</script>
+            <img src="${avatar}" alt="${escTitle}" height="100" width="100" />
+            <h1>${escName}</h1>
+            <h2>${escDescription}</h2>
+          </body>
+        </html>
+      `;
     }
-
-    const { data } = await apolloClient.query({
-      query: GroupDocument,
-      variables: { request: { group: address } },
-      fetchPolicy: "no-cache"
-    });
-
-    if (!data.group) {
-      return ctx.html(defaultMetadata, 404);
-    }
-
-    const group = data.group as GroupFragment;
-    const name = group.metadata?.name || "Group";
-    const title = `${name} on Hey`;
-    const description = (group?.metadata?.description || title).slice(0, 155);
-    const avatar = getAvatar(group, TRANSFORMS.AVATAR_BIG);
-
-    const escTitle = escapeHtml(title);
-    const escDescription = escapeHtml(description);
-    const escName = escapeHtml(name);
-
-    const jsonLd = {
-      "@context": "https://schema.org",
-      "@type": "Organization",
-      "@id": `https://hey.xyz/g/${address}`,
-      name,
-      alternateName: address,
-      description,
-      image: avatar,
-      url: `https://hey.xyz/g/${address}`,
-      memberOf: { "@type": "Organization", name: "Hey.xyz" }
-    };
-
-    const escapedJsonLd = JSON.stringify(jsonLd)
-      .replace(/</g, "\\u003c")
-      .replace(/>/g, "\\u003e")
-      .replace(/&/g, "\\u0026");
-
-    const ogHtml = html`
-      <html>
-        <head>
-          <meta charSet="utf-8" />
-          <meta name="viewport" content="width=device-width" />
-          <title>${escTitle}</title>
-          <meta name="description" content="${escDescription}" />
-          <meta property="og:title" content="${escTitle}" />
-          <meta property="og:description" content="${escDescription}" />
-          <meta property="og:type" content="profile" />
-          <meta property="og:site_name" content="Hey" />
-          <meta property="og:url" content="https://hey.xyz/g/${group.address}" />
-          <meta property="og:image" content="${avatar}" />
-          <meta property="og:logo" content="${STATIC_IMAGES_URL}/app-icon/0.png" />
-          <meta name="twitter:card" content="summary" />
-          <meta name="twitter:title" content="${escTitle}" />
-          <meta name="twitter:description" content="${escDescription}" />
-          <meta property="twitter:image" content="${avatar}" />
-          <meta name="twitter:site" content="@heydotxyz" />
-          <link rel="canonical" href="https://hey.xyz/g/${group.address}" />
-        </head>
-        <body>
-          <script type="application/ld+json">${raw(escapedJsonLd)}</script>
-          <img src="${avatar}" alt="${escTitle}" height="100" width="100" />
-          <h1>${escName}</h1>
-          <h2>${escDescription}</h2>
-        </body>
-      </html>
-    `;
-
-    const cleanHtml = ogHtml.toString().replace(/\n\s+/g, "").trim();
-    await setRedis(cacheKey, cleanHtml);
-
-    return ctx.html(cleanHtml, 200);
-  } catch {
-    return ctx.html(defaultMetadata, 500);
-  }
+  });
 };
 
 export default getGroup;

--- a/apps/api/src/routes/og/getPost.ts
+++ b/apps/api/src/routes/og/getPost.ts
@@ -4,89 +4,90 @@ import getAccount from "@hey/helpers/getAccount";
 import getAvatar from "@hey/helpers/getAvatar";
 import getPostData from "@hey/helpers/getPostData";
 import { PostDocument, type PostFragment } from "@hey/indexer";
-import apolloClient from "@hey/indexer/apollo/client";
 import type { Context } from "hono";
 import { html } from "hono/html";
-import defaultMetadata from "src/utils/defaultMetadata";
-import { getRedis, setRedis } from "src/utils/redis";
+import generateOg from "./ogUtils";
 
 const getPost = async (ctx: Context) => {
-  try {
-    const { slug } = ctx.req.param();
-    const cacheKey = `og:post:${slug}`;
-    const cachedPost = await getRedis(cacheKey);
+  const { slug } = ctx.req.param();
+  const cacheKey = `og:post:${slug}`;
 
-    if (cachedPost) {
-      return ctx.html(cachedPost, 200);
+  return generateOg({
+    ctx,
+    cacheKey,
+    query: PostDocument,
+    variables: { request: { post: slug } },
+    extractData: (data) => data.post as PostFragment | null,
+    buildJsonLd: (post: PostFragment) => {
+      const { author, metadata } = post;
+      const { usernameWithPrefix } = getAccount(author);
+      const filteredContent = getPostData(metadata)?.content || "";
+      const title = `${post.__typename} by ${usernameWithPrefix} on Hey`;
+      const description = (filteredContent || title).slice(0, 155);
+
+      return {
+        "@context": "https://schema.org",
+        "@type": "Article",
+        "@id": `https://hey.xyz/posts/${post.slug}`,
+        headline: title,
+        description,
+        author: usernameWithPrefix,
+        image: getAvatar(author, TRANSFORMS.AVATAR_BIG),
+        url: `https://hey.xyz/posts/${post.slug}`,
+        publisher: { "@type": "Organization", name: "Hey.xyz" }
+      };
+    },
+    buildHtml: (post: PostFragment, _jsonLd) => {
+      const { author, metadata } = post;
+      const { usernameWithPrefix } = getAccount(author);
+      const filteredContent = getPostData(metadata)?.content || "";
+      const title = `${post.__typename} by ${usernameWithPrefix} on Hey`;
+      const description = (filteredContent || title).slice(0, 155);
+      const postUrl = `https://hey.xyz/posts/${post.slug}`;
+
+      const escTitle = escapeHtml(title);
+      const escDescription = escapeHtml(description);
+
+      return html`
+        <html>
+          <head>
+            <meta charSet="utf-8" />
+            <meta name="viewport" content="width=device-width" />
+            <title>${escTitle}</title>
+            <meta name="description" content="${escDescription}" />
+            <meta property="og:title" content="${escTitle}" />
+            <meta property="og:description" content="${escDescription}" />
+            <meta property="og:type" content="article" />
+            <meta property="og:site_name" content="Hey" />
+            <meta property="og:url" content="https://hey.xyz/posts/${post.slug}" />
+            <meta property="og:logo" content="${STATIC_IMAGES_URL}/app-icon/0.png" />
+            <meta property="og:image" content="${getAvatar(author, TRANSFORMS.AVATAR_BIG)}" />
+            <meta name="twitter:card" content="summary" />
+            <meta name="twitter:title" content="${escTitle}" />
+            <meta name="twitter:description" content="${escDescription}" />
+            <meta property="twitter:image" content="${getAvatar(author, TRANSFORMS.AVATAR_BIG)}" />
+            <meta name="twitter:site" content="@heydotxyz" />
+            <link rel="canonical" href="https://hey.xyz/posts/${post.slug}" />
+          </head>
+          <body>
+            <h1>${escTitle}</h1>
+            <h2>${escDescription}</h2>
+            <div>
+              <b>Stats</b>
+              <ul>
+                <li><a href="${postUrl}">Collects: ${post.stats.collects}</a></li>
+                <li><a href="${postUrl}">Tips: ${post.stats.tips}</a></li>
+                <li><a href="${postUrl}">Comments: ${post.stats.comments}</a></li>
+                <li><a href="${postUrl}">Likes: ${post.stats.reactions}</a></li>
+                <li><a href="${postUrl}">Reposts: ${post.stats.reposts}</a></li>
+                <li><a href="${postUrl}/quotes">Quotes: ${post.stats.quotes}</a></li>
+              </ul>
+            </div>
+          </body>
+        </html>
+      `;
     }
-
-    const { data } = await apolloClient.query({
-      query: PostDocument,
-      variables: { request: { post: slug } },
-      fetchPolicy: "no-cache"
-    });
-
-    if (!data.post) {
-      return ctx.html(defaultMetadata, 404);
-    }
-
-    const post = data.post as PostFragment;
-    const { author, metadata } = post;
-    const { usernameWithPrefix } = getAccount(author);
-    const filteredContent = getPostData(metadata)?.content || "";
-    const title = `${post.__typename} by ${usernameWithPrefix} on Hey`;
-    const description = (filteredContent || title).slice(0, 155);
-    const postUrl = `https://hey.xyz/posts/${post.slug}`;
-
-    const escTitle = escapeHtml(title);
-    const escDescription = escapeHtml(description);
-
-    const ogHtml = html`
-      <html>
-        <head>
-          <meta charSet="utf-8" />
-          <meta name="viewport" content="width=device-width" />
-          <title>${escTitle}</title>
-          <meta name="description" content="${escDescription}" />
-          <meta property="og:title" content="${escTitle}" />
-          <meta property="og:description" content="${escDescription}" />
-          <meta property="og:type" content="article" />
-          <meta property="og:site_name" content="Hey" />
-          <meta property="og:url" content="https://hey.xyz/posts/${post.slug}" />
-          <meta property="og:logo" content="${STATIC_IMAGES_URL}/app-icon/0.png" />
-          <meta property="og:image" content="${getAvatar(author, TRANSFORMS.AVATAR_BIG)}" />
-          <meta name="twitter:card" content="summary" />
-          <meta name="twitter:title" content="${escTitle}" />
-          <meta name="twitter:description" content="${escDescription}" />
-          <meta property="twitter:image" content="${getAvatar(author, TRANSFORMS.AVATAR_BIG)}" />
-          <meta name="twitter:site" content="@heydotxyz" />
-          <link rel="canonical" href="https://hey.xyz/posts/${post.slug}" />
-        </head>
-        <body>
-          <h1>${escTitle}</h1>
-          <h2>${escDescription}</h2>
-          <div>
-            <b>Stats</b>
-            <ul>
-              <li><a href="${postUrl}">Collects: ${post.stats.collects}</a></li>
-              <li><a href="${postUrl}">Tips: ${post.stats.tips}</a></li>
-              <li><a href="${postUrl}">Comments: ${post.stats.comments}</a></li>
-              <li><a href="${postUrl}">Likes: ${post.stats.reactions}</a></li>
-              <li><a href="${postUrl}">Reposts: ${post.stats.reposts}</a></li>
-              <li><a href="${postUrl}/quotes">Quotes: ${post.stats.quotes}</a></li>
-            </ul>
-          </div>
-        </body>
-      </html>
-    `;
-
-    const cleanHtml = ogHtml.toString().replace(/\n\s+/g, "").trim();
-    await setRedis(cacheKey, cleanHtml);
-
-    return ctx.html(cleanHtml, 200);
-  } catch {
-    return ctx.html(defaultMetadata, 500);
-  }
+  });
 };
 
 export default getPost;

--- a/apps/api/src/routes/og/ogUtils.test.ts
+++ b/apps/api/src/routes/og/ogUtils.test.ts
@@ -1,0 +1,106 @@
+import apolloClient from "@hey/indexer/apollo/client";
+import type { Context } from "hono";
+import { html, raw } from "hono/html";
+import defaultMetadata from "src/utils/defaultMetadata";
+import { getRedis, setRedis } from "src/utils/redis";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import generateOg from "./ogUtils";
+
+vi.mock("@hey/indexer/apollo/client", () => ({
+  default: { query: vi.fn(async () => ({ data: { foo: "bar" } })) }
+}));
+vi.mock("src/utils/redis", () => ({ getRedis: vi.fn(), setRedis: vi.fn() }));
+
+const template = (_: any, jsonLd: string) =>
+  html`<html><script>${raw(jsonLd)}</script><body>bar</body></html>`;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("generateOg", () => {
+  it("returns cached value", async () => {
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      "cached"
+    );
+    const htmlFn = vi.fn((v: string) => v);
+    const ctx = { html: htmlFn } as unknown as Context;
+
+    const result = await generateOg({
+      ctx,
+      cacheKey: "k",
+      query: {} as any,
+      variables: {},
+      extractData: (d) => d,
+      buildJsonLd: () => ({}),
+      buildHtml: template
+    });
+
+    expect(htmlFn).toHaveBeenCalledWith("cached", 200);
+    expect(result).toBe("cached");
+    expect(apolloClient.query).not.toHaveBeenCalled();
+  });
+
+  it("queries and caches result", async () => {
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    const htmlFn = vi.fn((v: string) => v);
+    const ctx = { html: htmlFn } as unknown as Context;
+
+    const result = await generateOg({
+      ctx,
+      cacheKey: "k",
+      query: {} as any,
+      variables: {},
+      extractData: (d) => d,
+      buildJsonLd: () => ({}),
+      buildHtml: template
+    });
+
+    expect(apolloClient.query).toHaveBeenCalled();
+    expect(setRedis).toHaveBeenCalled();
+    expect(String(result)).toContain("bar");
+  });
+
+  it("returns default metadata when data missing", async () => {
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    (
+      apolloClient.query as unknown as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({ data: {} });
+    const htmlFn = vi.fn((v: any) => v);
+    const ctx = { html: htmlFn } as unknown as Context;
+
+    const result = await generateOg({
+      ctx,
+      cacheKey: "k",
+      query: {} as any,
+      variables: {},
+      extractData: () => null,
+      buildJsonLd: () => ({}),
+      buildHtml: template
+    });
+
+    expect(htmlFn).toHaveBeenCalledWith(defaultMetadata, 404);
+    expect(result).toBe(defaultMetadata);
+  });
+
+  it("handles errors gracefully", async () => {
+    (getRedis as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("fail")
+    );
+    const htmlFn = vi.fn((v: any) => v);
+    const ctx = { html: htmlFn } as unknown as Context;
+
+    const result = await generateOg({
+      ctx,
+      cacheKey: "k",
+      query: {} as any,
+      variables: {},
+      extractData: (d) => d,
+      buildJsonLd: () => ({}),
+      buildHtml: template
+    });
+
+    expect(htmlFn).toHaveBeenCalledWith(defaultMetadata, 500);
+    expect(result).toBe(defaultMetadata);
+  });
+});

--- a/apps/api/src/routes/og/ogUtils.ts
+++ b/apps/api/src/routes/og/ogUtils.ts
@@ -1,0 +1,63 @@
+import apolloClient from "@hey/indexer/apollo/client";
+import type { Context } from "hono";
+import type { HtmlEscapedString } from "hono/utils/html";
+import defaultMetadata from "src/utils/defaultMetadata";
+import { getRedis, setRedis } from "src/utils/redis";
+
+export interface OgHelperOptions<T> {
+  ctx: Context;
+  cacheKey: string;
+  query: any;
+  variables: Record<string, any>;
+  extractData: (data: any) => T | null;
+  buildJsonLd: (data: T) => Record<string, any>;
+  buildHtml: (
+    data: T,
+    escapedJsonLd: string
+  ) => HtmlEscapedString | Promise<HtmlEscapedString>;
+}
+
+const generateOg = async <T>({
+  ctx,
+  cacheKey,
+  query,
+  variables,
+  extractData,
+  buildJsonLd,
+  buildHtml
+}: OgHelperOptions<T>) => {
+  try {
+    const cached = await getRedis(cacheKey);
+    if (cached) {
+      return ctx.html(cached, 200);
+    }
+
+    const { data } = await apolloClient.query({
+      query,
+      variables,
+      fetchPolicy: "no-cache"
+    });
+
+    const parsed = extractData(data);
+    if (!parsed) {
+      return ctx.html(defaultMetadata, 404);
+    }
+
+    const jsonLd = buildJsonLd(parsed);
+    const escapedJsonLd = JSON.stringify(jsonLd)
+      .replace(/</g, "\\u003c")
+      .replace(/>/g, "\\u003e")
+      .replace(/&/g, "\\u0026");
+
+    const ogHtml = buildHtml(parsed, escapedJsonLd);
+    const cleanHtml = ogHtml.toString().replace(/\n\s+/g, "").trim();
+
+    await setRedis(cacheKey, cleanHtml);
+
+    return ctx.html(cleanHtml, 200);
+  } catch {
+    return ctx.html(defaultMetadata, 500);
+  }
+};
+
+export default generateOg;


### PR DESCRIPTION
## Summary
- centralize OG generation logic in `ogUtils`
- reuse helper in account, group and post routes
- add unit tests for new helper

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684d70089fbc83308a925faf25a07ab4