### PR TITLE
Update regex comment and fix typo

### DIFF
--- a/apps/web/src/components/Shared/Alert/BlockOrUnblockAccount.tsx
+++ b/apps/web/src/components/Shared/Alert/BlockOrUnblockAccount.tsx
@@ -112,7 +112,7 @@ const BlockOrUnblockAccount = () => {
       confirmText={hasBlocked ? "Unblock" : "Block"}
       description={`Are you sure you want to ${
         hasBlocked ? "unblock" : "block"
-      } ${getAccount(blockingorUnblockingAccount).usernameWithPrefix}?`}
+      } ${getAccount(blockingOrUnblockingAccount).usernameWithPrefix}?`}
       isPerformingAction={isSubmitting}
       onClose={() => setShowBlockOrUnblockAlert(false)}
       onConfirm={blockOrUnblock}

--- a/packages/data/regex.ts
+++ b/packages/data/regex.ts
@@ -2,8 +2,8 @@ import regexLookbehindAvailable from "./utils/regexLookbehindAvailable";
 
 const RESTRICTED_SYMBOLS = "☑️✓✔✅";
 
-// We only want to match mention when the `@` character is at the start of the
-// line or right after a whitespace.
+// We only want to match a mention when the `@` character is at the start of the
+// line or immediately after whitespace.
 const MATCH_BEHIND = regexLookbehindAvailable ? "(?<=^|\\s)" : "";
 
 const MENTION_NAMESPACE = "\\w+\\/";


### PR DESCRIPTION
## Summary
- clarify mention-matching comment in regex
- fix typo in BlockOrUnblockAccount.tsx

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684d7ad401f08330bec56c59e6d099bc