### PR TITLE
Fix getFavicon return type

### DIFF
--- a/apps/web/src/helpers/getFavicon.ts
+++ b/apps/web/src/helpers/getFavicon.ts
@@ -2,16 +2,15 @@ const FAVICON_BASE_URL = "https://external-content.duckduckgo.com/ip3";
 const UNKNOWN_DOMAIN = "unknowndomain";
 
 const getFavicon = (url: string): string => {
-  if (!url) {
-    return `${FAVICON_BASE_URL}/${UNKNOWN_DOMAIN}.ico`;
-  }
+  const domain = (() => {
+    try {
+      return new URL(url).hostname;
+    } catch {
+      return UNKNOWN_DOMAIN;
+    }
+  })();
 
-  try {
-    const { hostname } = new URL(url);
-    return `${FAVICON_BASE_URL}/${hostname || UNKNOWN_DOMAIN}.ico`;
-  } catch {
-    return `${FAVICON_BASE_URL}/${UNKNOWN_DOMAIN}.ico`;
-  }
+  return `${FAVICON_BASE_URL}/${domain || UNKNOWN_DOMAIN}.ico`;
 };
 
 export default getFavicon;


### PR DESCRIPTION
## Summary
- ensure `getFavicon` explicitly returns a string

## Testing
- `pnpm test`
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_684d9f53308483308a7b28e1231b4e89