### PR TITLE
feat(api): log errors before responding

### DIFF
--- a/apps/api/src/routes/cron/guild/syncFollowersStandingToGuild.ts
+++ b/apps/api/src/routes/cron/guild/syncFollowersStandingToGuild.ts
@@ -25,8 +25,8 @@ const syncFollowersStandingToGuild = async (ctx: Context) => {
     });
 
     return ctx.json(data);
-  } catch {
-    return handleApiError(ctx);
+  } catch (error) {
+    return handleApiError(ctx, error);
   }
 };
 

--- a/apps/api/src/routes/cron/guild/syncSubscribersToGuild.ts
+++ b/apps/api/src/routes/cron/guild/syncSubscribersToGuild.ts
@@ -31,8 +31,8 @@ const syncSubscribersToGuild = async (ctx: Context) => {
     });
 
     return ctx.json(data);
-  } catch {
-    return handleApiError(ctx);
+  } catch (error) {
+    return handleApiError(ctx, error);
   }
 };
 

--- a/apps/api/src/routes/cron/removeExpiredSubscribers/index.ts
+++ b/apps/api/src/routes/cron/removeExpiredSubscribers/index.ts
@@ -44,8 +44,8 @@ const removeExpiredSubscribers = async (ctx: Context) => {
     });
 
     return ctx.json({ addresses, hash, status: Status.Success });
-  } catch {
-    return handleApiError(ctx);
+  } catch (error) {
+    return handleApiError(ctx, error);
   }
 };
 

--- a/apps/api/src/routes/jumper/getStats.ts
+++ b/apps/api/src/routes/jumper/getStats.ts
@@ -63,8 +63,8 @@ const getStats = async (ctx: Context) => {
       status: Status.Success,
       tips: Number(result[0].count)
     });
-  } catch {
-    return handleApiError(ctx);
+  } catch (error) {
+    return handleApiError(ctx, error);
   }
 };
 

--- a/apps/api/src/routes/lens/authorization.ts
+++ b/apps/api/src/routes/lens/authorization.ts
@@ -24,8 +24,8 @@ const authorization = async (ctx: Context) => {
       signingKey: process.env.PRIVATE_KEY,
       sponsored: true
     });
-  } catch {
-    return handleApiError(ctx);
+  } catch (error) {
+    return handleApiError(ctx, error);
   }
 };
 

--- a/apps/api/src/routes/live/createLive.ts
+++ b/apps/api/src/routes/live/createLive.ts
@@ -45,8 +45,8 @@ const createLive = async (ctx: Context) => {
       },
       status: Status.Success
     });
-  } catch {
-    return handleApiError(ctx);
+  } catch (error) {
+    return handleApiError(ctx, error);
   }
 };
 

--- a/apps/api/src/routes/metadata/getSTS.ts
+++ b/apps/api/src/routes/metadata/getSTS.ts
@@ -42,8 +42,8 @@ const getSTS = async (ctx: Context) => {
       },
       status: Status.Success
     });
-  } catch {
-    return handleApiError(ctx);
+  } catch (error) {
+    return handleApiError(ctx, error);
   }
 };
 

--- a/apps/api/src/routes/oembed/getOembed.ts
+++ b/apps/api/src/routes/oembed/getOembed.ts
@@ -26,8 +26,8 @@ const getOembed = async (ctx: Context) => {
     await setRedis(cacheKey, oembed, generateExtraLongExpiry());
 
     return ctx.json({ data: oembed, status: Status.Success });
-  } catch {
-    return handleApiError(ctx);
+  } catch (error) {
+    return handleApiError(ctx, error);
   }
 };
 

--- a/apps/api/src/routes/preferences/getPreferences.ts
+++ b/apps/api/src/routes/preferences/getPreferences.ts
@@ -31,8 +31,8 @@ const getPreferences = async (ctx: Context) => {
     await setRedis(cacheKey, data);
 
     return ctx.json({ data, status: Status.Success });
-  } catch {
-    return handleApiError(ctx);
+  } catch (error) {
+    return handleApiError(ctx, error);
   }
 };
 

--- a/apps/api/src/routes/preferences/updatePreferences.ts
+++ b/apps/api/src/routes/preferences/updatePreferences.ts
@@ -24,8 +24,8 @@ const updatePreferences = async (ctx: Context) => {
       },
       status: Status.Success
     });
-  } catch {
-    return handleApiError(ctx);
+  } catch (error) {
+    return handleApiError(ctx, error);
   }
 };
 

--- a/apps/api/src/utils/handleApiError.ts
+++ b/apps/api/src/utils/handleApiError.ts
@@ -2,7 +2,15 @@ import { Status } from "@hey/data/enums";
 import { ERRORS } from "@hey/data/errors";
 import type { Context } from "hono";
 
-const handleApiError = (ctx: Context): Response =>
-  ctx.json({ error: ERRORS.SomethingWentWrong, status: Status.Error }, 500);
+const handleApiError = (ctx: Context, error?: unknown): Response => {
+  if (error) {
+    console.error(error);
+  }
+
+  return ctx.json(
+    { error: ERRORS.SomethingWentWrong, status: Status.Error },
+    500
+  );
+};
 
 export default handleApiError;


### PR DESCRIPTION
## Summary
- log caught errors in `handleApiError`
- forward caught errors to `handleApiError`

## Testing
- `pnpm biome:check`
- `pnpm typecheck`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68654cb2ad108330b58ce78b1937fa79