### PR TITLE
fix: add missing article on terms page

### DIFF
--- a/apps/web/src/components/Pages/Terms.tsx
+++ b/apps/web/src/components/Pages/Terms.tsx
@@ -38,8 +38,8 @@ const Terms = () => {
                   accessing the Site, you consent to the Agreement.
                 </p>
                 <p className="leading-7">
-                  Any new features or tools which are added to Site shall also
-                  be subject to the Terms. You can review the most current
+                  Any new features or tools which are added to the Site shall
+                  also be subject to the Terms. You can review the most current
                   version of the Terms at any time on this page. We reserve the
                   right to update, change or replace any part of these Terms by
                   posting updates and/or changes to our Site. It is your


### PR DESCRIPTION
## Summary
- ensure new tools are described as being added to the Site

## Testing
- `pnpm biome:check`
- `pnpm typecheck` *(fails: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory)*
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6890c1aadb1c8330a9d1f9bb6e23a39e