### PR TITLE
fix(api): remove duplicate localhost origin in CORS configuration

### DIFF
--- a/apps/api/src/middlewares/cors.ts
+++ b/apps/api/src/middlewares/cors.ts
@@ -7,8 +7,7 @@ const allowedOrigins = [
   "http://localhost:4783",
   "https://developer.lens.xyz",
   "https://yoginth.com",
-  "http://localhost:3000",
-  "http://localhost:4783"
+  "http://localhost:3000"
 ];
 
 const cors = corsMiddleware({


### PR DESCRIPTION
Remove duplicate "http://localhost:4783" entry from allowedOrigins array in CORS middleware to clean up configuration and improve maintainability.