### PR TITLE
docs: update README and AGENTS.md to reflect actual project structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,46 +1,45 @@
 # Repository Guidelines
 
-## Project Structure & Modules
+## Project Structure
 
-- `apps/web`: Vite + React 19 frontend (sources under `src/`, static assets in `public/`).
-- `apps/api`: Hono-based API server (entry `src/index.ts`, routes in `src/routes/`).
-- `packages/*`: Shared code (`helpers`, `data`, `types`, `indexer`, `config`).
-- `script/*`: Maintenance utilities (e.g., sorting `package.json`, cleaning branches).
-- Tooling: PNPM workspaces (`pnpm-workspace.yaml`), Biome config (`biome.json`), Husky hooks (`.husky/`).
+- `src/`: Application source code
+  - `components/`: React components organized by feature
+  - `data/`: Constants, configuration, and data utilities
+  - `helpers/`: Utility functions and helper modules
+  - `hooks/`: Custom React hooks
+  - `indexer/`: Apollo GraphQL client and code generation
+  - `store/`: Zustand state management
+  - `types/`: TypeScript type definitions
+- `public/`: Static assets served by the application
+- `script/`: Maintenance utilities (e.g., cleaning dependencies, sorting `package.json`)
+- Tooling: Biome config (`biome.json`), Husky hooks (`.husky/`)
 
 ## Build, Test, and Development
 
-- Root dev: `pnpm dev` — run all workspaces in watch mode.
-- Root build: `pnpm build` — build all workspaces in parallel.
-- Web app: `pnpm -F @hey/web dev` (preview: `pnpm -F @hey/web start`, build: `pnpm -F @hey/web build`).
-- API: `pnpm -F @hey/api dev` (typecheck: `pnpm -F @hey/api typecheck`).
-- Lint/format: `pnpm biome:check` (auto-fix: `pnpm biome:fix`).
-- Types: `pnpm typecheck` — TypeScript across the monorepo.
-- Node & PM: Node 20 (`.nvmrc`), PNPM 10 (see `package.json#packageManager`).
+- Dev: `pnpm dev` - run in watch mode on port 4783
+- Build: `pnpm build` - build for production
+- Preview: `pnpm start` - preview production build
+- Lint/format: `pnpm biome:check` (auto-fix: `pnpm biome:fix`)
+- Types: `pnpm typecheck` - TypeScript type checking
+- Node & PM: Node 20 (`.nvmrc`), pnpm 10 (see `package.json#packageManager`)
 
 ## Coding Style & Naming
 
-- Language: TypeScript (strict, shared configs in `packages/config`).
-- Formatting: Biome controls style; no trailing commas; spaces for indentation.
-- Imports: Use workspace packages (`@hey/*`) and web alias `@/*` to `apps/web/src`.
-- Files: React components `PascalCase.tsx`; helpers/stores `camelCase.ts`.
-- Keep modules small, colocate domain helpers with their feature when practical.
+- Language: TypeScript (strict mode)
+- Formatting: Biome controls style; no trailing commas; spaces for indentation
+- Imports: Use alias `@/*` to `src/`
+- Files: React components `PascalCase.tsx`; helpers/stores `camelCase.ts`
+- Keep modules small, colocate domain helpers with their feature when practical
 
 ## Testing Guidelines
 
-- Current status: no formal unit tests present. Enforce quality via `biome` and `tsc`.
-- If adding tests, prefer Vitest for web and lightweight integration tests for API.
-- Naming: `*.test.ts` or `*.test.tsx`, colocated with the code or under `__tests__/`.
-- Run with a future `pnpm test` script at root or per package.
+- Current status: no formal unit tests present. Enforce quality via `biome` and `tsc`
+- If adding tests, prefer Vitest for web and lightweight integration tests
+- Naming: `*.test.ts` or `*.test.tsx`, colocated with the code or under `__tests__/`
 
 ## Commit & Pull Requests
 
-- Commits: imperative mood, concise subject; optional scope like `web:`, `api:`, `helpers:`.
-- Include rationale and references (e.g., `Closes #123`).
-- PRs: clear description, screenshots for UI changes, reproduction steps for fixes, and env notes.
-- CI hooks: pre-commit runs `biome` and type checks; ensure both pass locally before pushing.
-
-## Security & Configuration
-
-- Copy `.env.example` to `.env` in `apps/web` and `apps/api`. Never commit secrets.
-- Validate envs at startup; keep keys minimal and documented near usage.
+- Commits: imperative mood, concise subject; optional scope like `web:`, `api:`, `helpers:`
+- Include rationale and references (e.g., `Closes #123`)
+- PRs: clear description, screenshots for UI changes, reproduction steps for fixes
+- CI hooks: pre-commit runs `biome` and type checks; ensure both pass locally before pushing

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
-# Hey Monorepo
+# Hey
+
+Hey is a social network built on [Lens Protocol](https://lens.xyz).
 
 ## Requirements
 
-To start working with the Hey monorepo, ensure the following tools are installed:
+To start working with Hey, ensure the following tools are installed:
 
-- [Node.js](https://nodejs.org/en/download/) (v18 or higher) – the JavaScript runtime used in this project.
-- [pnpm](https://pnpm.io/installation) – the package manager used throughout this repository.
-- [Postgres App](https://postgresapp.com/) – the Postgres database used in development.
+- [Node.js](https://nodejs.org/en/download/) (v20 or higher) - the JavaScript runtime used in this project.
+- [pnpm](https://pnpm.io/installation) - the package manager used throughout this repository.
 
 ## Installation
-
-This repository uses [pnpm workspaces](https://pnpm.io/workspaces) to manage multiple packages within a monorepo structure.
 
 ### Clone the Repository
 
@@ -42,25 +41,6 @@ From the repository root, install dependencies with pnpm:
 pnpm install
 ```
 
-### Set up Environment Variables
-
-Copy the `.env.example` file to `.env` for each package or application that requires configuration:
-
-```bash
-cp .env.example .env
-```
-
-Repeat this process for all relevant packages and applications in the monorepo.
-
-### Environment Variables
-
-The example environment files define the following variables:
-
-#### API (`apps/api/.env.example`)
-
-- `PRIVATE_KEY` – Private key used to sign Lens requests.
-- `SHARED_SECRET` – Token for internal API authorization.
-
 ### Start the Development Server
 
 To run the application in development mode:
@@ -68,6 +48,8 @@ To run the application in development mode:
 ```bash
 pnpm dev
 ```
+
+The application will be available at `http://localhost:4783`.
 
 ## Build
 
@@ -77,6 +59,14 @@ Compile the application:
 
 ```bash
 pnpm build
+```
+
+### Preview the build
+
+Run the production build locally:
+
+```bash
+pnpm start
 ```
 
 ### Type-check the project
@@ -107,7 +97,7 @@ Convenient Node.js helpers are in the `script` directory:
 
 - `node script/clean.mjs` removes all `node_modules`, `.next` directories,
   `pnpm-lock.yaml`, and `tsconfig.tsbuildinfo` files.
-- `node script/update-dependencies.mjs` updates packages across the monorepo,
+- `node script/update-dependencies.mjs` updates packages across the repository,
   removes old installs and commits the changes in a new branch.
 - `node script/sort-package-json.mjs` sorts all `package.json` files in the
   repository.
@@ -115,5 +105,3 @@ Convenient Node.js helpers are in the `script` directory:
 ## License
 
 This project is released under the **GNU AGPL-3.0** license. See the [LICENSE](./LICENSE) file for details.
-
-🌸


### PR DESCRIPTION
## Summary
- Remove references to non-existent monorepo structure (`apps/`, `packages/`, `pnpm-workspace.yaml`)
- Remove references to non-existent `.env.example` files
- Update Node.js version requirement from v18 to v20 (per `.nvmrc`)
- Add missing information about dev server port (4783) and preview command
- Simplify documentation to match the actual single-app structure
- Add project description with link to Lens Protocol

## Context
The current README and AGENTS.md reference a monorepo structure with `apps/web`, `apps/api`, and `packages/*` directories that don't exist in the repository. This PR updates the documentation to accurately reflect the actual project structure.

## Test plan
- [ ] Review that documentation accurately describes the project
- [ ] Verify all referenced paths and commands work correctly